### PR TITLE
feat: add sidebar profile

### DIFF
--- a/spa/package-lock.json
+++ b/spa/package-lock.json
@@ -8,6 +8,7 @@
       "name": "stuf-spa",
       "version": "0.1.0",
       "dependencies": {
+        "@radix-ui/react-avatar": "^1.1.10",
         "@radix-ui/react-slot": "^1.2.3",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
@@ -22,6 +23,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.36.0",
+        "@faker-js/faker": "^10.0.0",
         "@storybook/addon-a11y": "^9.1.10",
         "@storybook/addon-designs": "^10.0.2",
         "@storybook/addon-docs": "^9.1.10",
@@ -1116,6 +1118,23 @@
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
+    "node_modules/@faker-js/faker": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@faker-js/faker/-/faker-10.0.0.tgz",
+      "integrity": "sha512-UollFEUkVXutsaP+Vndjxar40Gs5JL2HeLcl8xO1QAjJgOdhc3OmBFWyEylS+RddWaaBiAzH+5/17PLQJwDiLw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fakerjs"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || ^23.5.0 || >=24.0.0",
+        "npm": ">=10"
+      }
+    },
     "node_modules/@figspec/components": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@figspec/components/-/components-1.0.3.tgz",
@@ -1451,6 +1470,33 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@radix-ui/react-avatar": {
+      "version": "1.1.10",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-avatar/-/react-avatar-1.1.10.tgz",
+      "integrity": "sha512-V8piFfWapM5OmNCXTzVQY+E1rDa53zY+MQ4Y7356v4fFz6vqCyUtIz2rUD44ZEdwg78/jKmMJHj07+C/Z/rcog==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-is-hydrated": "0.1.0",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-compose-refs": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.2.tgz",
@@ -1466,6 +1512,44 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-context": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.2.tgz",
+      "integrity": "sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
+      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-slot": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
@@ -1474,6 +1558,54 @@
       "dependencies": {
         "@radix-ui/react-compose-refs": "1.1.2"
       },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-callback-ref": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.1.tgz",
+      "integrity": "sha512-FkBMwD+qbGQeMu1cOHnuGB6x4yzPjho8ap5WtbEJ26umhgqVXbhekKUQO+hZEL1vU92a3wHwdp0HAcqAUF5iDg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-is-hydrated": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-is-hydrated/-/react-use-is-hydrated-0.1.0.tgz",
+      "integrity": "sha512-U+UORVEq+cTnRIaostJv9AGdV3G6Y+zbVd+12e18jQ5A3c0xL03IhnHuiU4UV69wolOQp5GfR58NW/EgdQhwOA==",
+      "license": "MIT",
+      "dependencies": {
+        "use-sync-external-store": "^1.5.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-layout-effect": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.1.tgz",
+      "integrity": "sha512-RbJRS4UWQFkzHTTwVymMTUv8EqYhOp8dOOviLj2ugtTiXRaRQS7GLGxZTLL1jWhMeoSCf5zmcZkqTl9IiYfXcQ==",
+      "license": "MIT",
       "peerDependencies": {
         "@types/react": "*",
         "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
@@ -2663,7 +2795,7 @@
       "version": "19.1.9",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.1.9.tgz",
       "integrity": "sha512-qXRuZaOsAdXKFyOhRBg6Lqqc0yay13vN7KrIg4L7N4aaHN68ma9OK3NE1BoDFgFOTfM7zg+3/8+2n8rLUH3OKQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.0.0"
@@ -8562,6 +8694,15 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/vite": {

--- a/spa/package.json
+++ b/spa/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
+    "@radix-ui/react-avatar": "^1.1.10",
     "@radix-ui/react-slot": "^1.2.3",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
@@ -49,6 +50,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.36.0",
+    "@faker-js/faker": "^10.0.0",
     "@storybook/addon-a11y": "^9.1.10",
     "@storybook/addon-designs": "^10.0.2",
     "@storybook/addon-docs": "^9.1.10",

--- a/spa/src/components/sidebar/profile/SidebarProfile.stories.tsx
+++ b/spa/src/components/sidebar/profile/SidebarProfile.stories.tsx
@@ -1,0 +1,82 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { faker } from "@faker-js/faker";
+import { SidebarProfile } from "./SidebarProfile";
+
+const meta = {
+  title: "Components/Sidebar/SidebarProfile",
+  component: SidebarProfile,
+  parameters: {
+    layout: "centered",
+    design: {
+      type: "figma",
+      url: "https://www.figma.com/design/SQOopW8mFNB8TLQSZvOySp/STUF-UI?node-id=9-2254&m=dev",
+    },
+  },
+  decorators: [
+    (Story) => {
+      return (
+        <div className="w-[280px] bg-background p-4">
+          <Story />
+        </div>
+      );
+    },
+  ],
+  tags: ["autodocs"],
+  argTypes: {
+    name: {
+      control: "text",
+      description: "User's full name",
+    },
+    email: {
+      control: "text",
+      description: "User's email address",
+    },
+    avatarUrl: {
+      control: "text",
+      description: "URL to user's avatar image",
+    },
+  },
+} satisfies Meta<typeof SidebarProfile>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    name: faker.person.fullName(),
+    email: faker.internet.email(),
+    avatarUrl: faker.image.avatar(),
+  },
+};
+
+export const WithPlaceholder: Story = {
+  args: {
+    name: "Cindy Reardon",
+    email: "c.reardon@emailadress.com",
+  },
+};
+
+export const TruncatedName: Story = {
+  args: {
+    name: "Dr. Christopher Alexander Montgomery Wellington III",
+    email: "c.montgomery@example.com",
+    avatarUrl: faker.image.avatar(),
+  },
+};
+
+export const TruncatedEmail: Story = {
+  args: {
+    name: "Jane Doe",
+    email:
+      "jane.doe.with.a.very.long.email.address@corporate-company-domain.com",
+    avatarUrl: faker.image.avatar(),
+  },
+};
+
+export const BothTruncated: Story = {
+  args: {
+    name: "Dr. Alexander Christopher Montgomery Wellington",
+    email: "alexander.christopher.montgomery@very-long-corporate-domain.com",
+    avatarUrl: faker.image.avatar(),
+  },
+};

--- a/spa/src/components/sidebar/profile/SidebarProfile.test.tsx
+++ b/spa/src/components/sidebar/profile/SidebarProfile.test.tsx
@@ -1,0 +1,60 @@
+import { render, screen } from "@testing-library/react";
+import { SidebarProfile } from "./SidebarProfile";
+
+describe("SidebarProfile", () => {
+  it("renders name and email", () => {
+    render(<SidebarProfile name="John Doe" email="john@example.com" />);
+
+    expect(screen.getByTestId("sidebar-profile-name")).toHaveTextContent(
+      "John Doe",
+    );
+    expect(screen.getByTestId("sidebar-profile-email")).toHaveTextContent(
+      "john@example.com",
+    );
+  });
+
+  it("renders fallback with initials when avatarUrl is not provided", () => {
+    render(<SidebarProfile name="John Doe" email="john@example.com" />);
+
+    expect(
+      screen.getByTestId("sidebar-profile-avatar-fallback"),
+    ).toHaveTextContent("JD");
+  });
+
+  it("truncates long names", () => {
+    render(
+      <SidebarProfile
+        name="Dr. Christopher Alexander Montgomery Wellington III"
+        email="short@example.com"
+      />,
+    );
+
+    const nameElement = screen.getByTestId("sidebar-profile-name");
+    expect(nameElement).toHaveClass("truncate");
+  });
+
+  it("truncates long emails", () => {
+    render(
+      <SidebarProfile
+        name="Jane Doe"
+        email="very.long.email.address@corporate-company-domain.com"
+      />,
+    );
+
+    const emailElement = screen.getByTestId("sidebar-profile-email");
+    expect(emailElement).toHaveClass("truncate");
+  });
+
+  it("renders with custom className", () => {
+    render(
+      <SidebarProfile
+        name="John Doe"
+        email="john@example.com"
+        className="custom-class"
+      />,
+    );
+
+    const profile = screen.getByTestId("sidebar-profile");
+    expect(profile).toHaveClass("custom-class");
+  });
+});

--- a/spa/src/components/sidebar/profile/SidebarProfile.tsx
+++ b/spa/src/components/sidebar/profile/SidebarProfile.tsx
@@ -1,0 +1,47 @@
+import { cn, getInitials } from "@/lib/utils";
+import { Avatar, AvatarImage, AvatarFallback } from "@/components/ui/avatar";
+
+interface SidebarProfileProps {
+  name: string;
+  email: string;
+  avatarUrl?: string;
+  className?: string;
+}
+
+export function SidebarProfile({
+  name,
+  email,
+  avatarUrl,
+  className,
+}: SidebarProfileProps) {
+  return (
+    <div
+      className={cn("flex items-center gap-2", className)}
+      data-testid="sidebar-profile"
+    >
+      <Avatar className="w-10 h-10 rounded-[20px]">
+        <AvatarImage src={avatarUrl} alt={`${name}'s avatar`} />
+        <AvatarFallback
+          className="rounded-[20px] bg-primary text-primary-text text-sm font-medium"
+          data-testid="sidebar-profile-avatar-fallback"
+        >
+          {getInitials(name)}
+        </AvatarFallback>
+      </Avatar>
+      <div className="flex flex-col min-w-0 flex-1">
+        <div
+          className="text-foreground text-base font-normal leading-7 truncate"
+          data-testid="sidebar-profile-name"
+        >
+          {name}
+        </div>
+        <div
+          className="text-foreground text-sm font-normal leading-none truncate"
+          data-testid="sidebar-profile-email"
+        >
+          {email}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/spa/src/components/sidebar/profile/index.ts
+++ b/spa/src/components/sidebar/profile/index.ts
@@ -1,0 +1,1 @@
+export { SidebarProfile } from "./SidebarProfile";

--- a/spa/src/components/ui/avatar.tsx
+++ b/spa/src/components/ui/avatar.tsx
@@ -1,0 +1,48 @@
+import * as React from "react";
+import * as AvatarPrimitive from "@radix-ui/react-avatar";
+
+import { cn } from "@/lib/utils";
+
+const Avatar = React.forwardRef<
+  React.ElementRef<typeof AvatarPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof AvatarPrimitive.Root>
+>(({ className, ...props }, ref) => (
+  <AvatarPrimitive.Root
+    ref={ref}
+    className={cn(
+      "relative flex h-10 w-10 shrink-0 overflow-hidden rounded-full",
+      className,
+    )}
+    {...props}
+  />
+));
+Avatar.displayName = AvatarPrimitive.Root.displayName;
+
+const AvatarImage = React.forwardRef<
+  React.ElementRef<typeof AvatarPrimitive.Image>,
+  React.ComponentPropsWithoutRef<typeof AvatarPrimitive.Image>
+>(({ className, ...props }, ref) => (
+  <AvatarPrimitive.Image
+    ref={ref}
+    className={cn("aspect-square h-full w-full", className)}
+    {...props}
+  />
+));
+AvatarImage.displayName = AvatarPrimitive.Image.displayName;
+
+const AvatarFallback = React.forwardRef<
+  React.ElementRef<typeof AvatarPrimitive.Fallback>,
+  React.ComponentPropsWithoutRef<typeof AvatarPrimitive.Fallback>
+>(({ className, ...props }, ref) => (
+  <AvatarPrimitive.Fallback
+    ref={ref}
+    className={cn(
+      "flex h-full w-full items-center justify-center rounded-full bg-muted",
+      className,
+    )}
+    {...props}
+  />
+));
+AvatarFallback.displayName = AvatarPrimitive.Fallback.displayName;
+
+export { Avatar, AvatarImage, AvatarFallback };

--- a/spa/src/lib/utils.test.ts
+++ b/spa/src/lib/utils.test.ts
@@ -1,0 +1,55 @@
+import { getInitials } from "./utils";
+
+describe("getInitials", () => {
+  it("returns initials from full name", () => {
+    expect(getInitials("John Doe")).toBe("JD");
+  });
+
+  it("returns initials from name with multiple words", () => {
+    expect(getInitials("John Michael Doe")).toBe("JM");
+  });
+
+  it("returns uppercase initials", () => {
+    expect(getInitials("john doe")).toBe("JD");
+  });
+
+  it("handles hyphenated names", () => {
+    expect(getInitials("Mary-Jane Watson")).toBe("MJ");
+  });
+
+  it("handles names with multiple hyphens", () => {
+    expect(getInitials("Jean-Claude Van-Damme")).toBe("JC");
+  });
+
+  it("returns single initial for single name", () => {
+    expect(getInitials("Madonna")).toBe("M");
+  });
+
+  it("returns empty string for empty name", () => {
+    expect(getInitials("")).toBe("");
+  });
+
+  it("handles names with extra whitespace", () => {
+    expect(getInitials("  John   Doe  ")).toBe("JD");
+  });
+
+  it("respects maxLetters parameter", () => {
+    expect(getInitials("John Michael Doe", 3)).toBe("JMD");
+  });
+
+  it("handles names with mixed spaces and hyphens", () => {
+    expect(getInitials("Mary Jane-Watson Smith")).toBe("MJ");
+  });
+
+  it("handles names with only spaces", () => {
+    expect(getInitials("   ")).toBe("");
+  });
+
+  it("handles names with special characters", () => {
+    expect(getInitials("O'Brien Smith")).toBe("OS");
+  });
+
+  it("returns first two initials by default", () => {
+    expect(getInitials("Alexander Benjamin Christopher David")).toBe("AB");
+  });
+});

--- a/spa/src/lib/utils.ts
+++ b/spa/src/lib/utils.ts
@@ -4,3 +4,15 @@ import { twMerge } from "tailwind-merge";
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
 }
+
+export function getInitials(name: string, maxLetters = 2): string {
+  if (!name) return "";
+
+  return name
+    .trim()
+    .split(/[\s-]+/) // split on spaces OR hyphens
+    .map((word) => word[0]?.toUpperCase())
+    .filter(Boolean)
+    .slice(0, maxLetters)
+    .join("");
+}


### PR DESCRIPTION
This PR adds a sidebar profile component based on the high-fidelity design, stories and unit tests.

### Unit Tests
<img width="1650" height="953" alt="Screenshot 2025-10-03 at 5 35 17 pm" src="https://github.com/user-attachments/assets/cbfaf9b2-df3d-4fe8-b4c3-f1f35d51b443" />

### Documentation
<img width="1746" height="1138" alt="Screenshot 2025-10-03 at 5 11 58 pm" src="https://github.com/user-attachments/assets/18984615-421f-48fa-862d-df97555b5ee8" />
<img width="1746" height="1138" alt="Screenshot 2025-10-03 at 5 12 20 pm" src="https://github.com/user-attachments/assets/f0059738-81a7-4ee5-90ea-bedb5535f554" />
<img width="1746" height="1138" alt="Screenshot 2025-10-03 at 5 12 34 pm" src="https://github.com/user-attachments/assets/70b85f0b-f95a-4475-9fbd-4704c9f916c7" />

### Light Mode
<img width="1746" height="1138" alt="Screenshot 2025-10-03 at 5 11 15 pm" src="https://github.com/user-attachments/assets/75e7312f-3f7b-4342-9229-2c403e5b3053" />

### Dark Mode
<img width="1746" height="1138" alt="Screenshot 2025-10-03 at 5 11 20 pm" src="https://github.com/user-attachments/assets/fd2b3cce-1076-4277-a261-59692421dc26" />