### PR TITLE
feat: add table pagination

### DIFF
--- a/spa/src/components/table/table-pagination/TablePagination.stories.tsx
+++ b/spa/src/components/table/table-pagination/TablePagination.stories.tsx
@@ -1,0 +1,151 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { useState } from "react";
+import { TablePagination } from "./TablePagination";
+
+const meta: Meta<typeof TablePagination> = {
+  title: "Components/Table/TablePagination",
+  component: TablePagination,
+  parameters: {
+    layout: "padded",
+    design: {
+      type: "figma",
+      url: "https://www.figma.com/design/SQOopW8mFNB8TLQSZvOySp/RBTP-UI?node-id=95-2628&m=dev",
+    },
+  },
+  decorators: [
+    (Story) => {
+      return (
+        <div className="bg-background p-4">
+          <Story />
+        </div>
+      );
+    },
+  ],
+  tags: ["autodocs"],
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+// Default pagination
+export const Default: Story = {
+  render: () => {
+    const [currentPage, setCurrentPage] = useState(1);
+    const [pageSize, setPageSize] = useState(10);
+
+    return (
+      <TablePagination
+        currentPage={currentPage}
+        totalPages={13}
+        totalResults={123}
+        pageSize={pageSize}
+        onPageChange={setCurrentPage}
+        onPageSizeChange={setPageSize}
+      />
+    );
+  },
+};
+
+// First page
+export const FirstPage: Story = {
+  args: {
+    currentPage: 1,
+    totalPages: 10,
+    totalResults: 100,
+    pageSize: 10,
+    onPageChange: (page) => console.log("Page changed:", page),
+    onPageSizeChange: (size) => console.log("Page size changed:", size),
+  },
+};
+
+// Middle page
+export const MiddlePage: Story = {
+  args: {
+    currentPage: 5,
+    totalPages: 10,
+    totalResults: 100,
+    pageSize: 10,
+    onPageChange: (page) => console.log("Page changed:", page),
+    onPageSizeChange: (size) => console.log("Page size changed:", size),
+  },
+};
+
+// Last page
+export const LastPage: Story = {
+  args: {
+    currentPage: 10,
+    totalPages: 10,
+    totalResults: 100,
+    pageSize: 10,
+    onPageChange: (page) => console.log("Page changed:", page),
+    onPageSizeChange: (size) => console.log("Page size changed:", size),
+  },
+};
+
+// Few pages (only 1 page)
+export const FewPages: Story = {
+  args: {
+    currentPage: 1,
+    totalPages: 1,
+    totalResults: 10,
+    pageSize: 10,
+    onPageChange: (page) => console.log("Page changed:", page),
+    onPageSizeChange: (size) => console.log("Page size changed:", size),
+  },
+};
+
+// Many pages with ellipsis
+export const ManyPages: Story = {
+  args: {
+    currentPage: 15,
+    totalPages: 50,
+    totalResults: 500,
+    pageSize: 10,
+    onPageChange: (page) => console.log("Page changed:", page),
+    onPageSizeChange: (size) => console.log("Page size changed:", size),
+  },
+};
+
+// Custom page size options
+export const CustomPageSizes: Story = {
+  args: {
+    currentPage: 1,
+    totalPages: 10,
+    totalResults: 200,
+    pageSize: 20,
+    pageSizeOptions: [20, 50, 100, 200],
+    onPageChange: (page) => console.log("Page changed:", page),
+    onPageSizeChange: (size) => console.log("Page size changed:", size),
+  },
+};
+
+// Interactive example
+export const Interactive: Story = {
+  render: () => {
+    const [currentPage, setCurrentPage] = useState(1);
+    const [pageSize, setPageSize] = useState(10);
+    const totalResults = 237;
+    const totalPages = Math.ceil(totalResults / pageSize);
+
+    return (
+      <div className="space-y-4">
+        <TablePagination
+          currentPage={currentPage}
+          totalPages={totalPages}
+          totalResults={totalResults}
+          pageSize={pageSize}
+          onPageChange={setCurrentPage}
+          onPageSizeChange={(newSize) => {
+            setPageSize(newSize);
+            // Reset to page 1 when changing page size
+            setCurrentPage(1);
+          }}
+        />
+        <div className="text-sm text-muted-foreground">
+          Current page: {currentPage} | Page size: {pageSize} | Total pages:{" "}
+          {totalPages}
+        </div>
+      </div>
+    );
+  },
+};

--- a/spa/src/components/table/table-pagination/TablePagination.test.tsx
+++ b/spa/src/components/table/table-pagination/TablePagination.test.tsx
@@ -1,0 +1,621 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { TablePagination } from "./TablePagination";
+
+describe("TablePagination", () => {
+  const mockOnPageChange = vi.fn();
+  const mockOnPageSizeChange = vi.fn();
+
+  const defaultProps = {
+    currentPage: 1,
+    totalPages: 10,
+    totalResults: 100,
+    pageSize: 10,
+    onPageChange: mockOnPageChange,
+    onPageSizeChange: mockOnPageSizeChange,
+  };
+
+  beforeEach(() => {
+    mockOnPageChange.mockClear();
+    mockOnPageSizeChange.mockClear();
+  });
+
+  describe("Basic Rendering", () => {
+    it("renders pagination component", () => {
+      render(<TablePagination {...defaultProps} />);
+
+      expect(screen.getByTestId("table-pagination")).toBeInTheDocument();
+    });
+
+    it("displays results info correctly", () => {
+      render(<TablePagination {...defaultProps} />);
+
+      expect(
+        screen.getByTestId("table-pagination-results-info"),
+      ).toHaveTextContent("1-10 of 100 results");
+    });
+
+    it("displays correct results info on middle page", () => {
+      render(<TablePagination {...defaultProps} currentPage={5} />);
+
+      expect(
+        screen.getByTestId("table-pagination-results-info"),
+      ).toHaveTextContent("41-50 of 100 results");
+    });
+
+    it("displays correct results info on last page with partial results", () => {
+      render(
+        <TablePagination
+          {...defaultProps}
+          currentPage={10}
+          totalResults={95}
+        />,
+      );
+
+      expect(
+        screen.getByTestId("table-pagination-results-info"),
+      ).toHaveTextContent("91-95 of 95 results");
+    });
+
+    it("renders with custom testId", () => {
+      render(<TablePagination {...defaultProps} testId="custom-pagination" />);
+
+      expect(screen.getByTestId("custom-pagination")).toBeInTheDocument();
+      expect(
+        screen.getByTestId("custom-pagination-results-info"),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByTestId("custom-pagination-controls"),
+      ).toBeInTheDocument();
+    });
+
+    it("applies custom className", () => {
+      render(<TablePagination {...defaultProps} className="custom-class" />);
+
+      const pagination = screen.getByTestId("table-pagination");
+      expect(pagination).toHaveClass("custom-class");
+    });
+  });
+
+  describe("Navigation Controls", () => {
+    it("renders previous and next buttons", () => {
+      render(<TablePagination {...defaultProps} />);
+
+      expect(
+        screen.getByTestId("table-pagination-previous"),
+      ).toBeInTheDocument();
+      expect(screen.getByTestId("table-pagination-next")).toBeInTheDocument();
+    });
+
+    it("disables previous button on first page", () => {
+      render(<TablePagination {...defaultProps} currentPage={1} />);
+
+      const prevButton = screen.getByTestId("table-pagination-previous");
+      expect(prevButton).toBeDisabled();
+      expect(prevButton).toHaveClass("opacity-50", "cursor-not-allowed");
+    });
+
+    it("disables next button on last page", () => {
+      render(<TablePagination {...defaultProps} currentPage={10} />);
+
+      const nextButton = screen.getByTestId("table-pagination-next");
+      expect(nextButton).toBeDisabled();
+      expect(nextButton).toHaveClass("opacity-50", "cursor-not-allowed");
+    });
+
+    it("enables both buttons on middle page", () => {
+      render(<TablePagination {...defaultProps} currentPage={5} />);
+
+      const prevButton = screen.getByTestId("table-pagination-previous");
+      const nextButton = screen.getByTestId("table-pagination-next");
+
+      expect(prevButton).not.toBeDisabled();
+      expect(nextButton).not.toBeDisabled();
+      expect(prevButton).toHaveClass("cursor-pointer");
+      expect(nextButton).toHaveClass("cursor-pointer");
+    });
+
+    it("calls onPageChange when previous button is clicked", async () => {
+      const user = userEvent.setup();
+      render(<TablePagination {...defaultProps} currentPage={5} />);
+
+      await user.click(screen.getByTestId("table-pagination-previous"));
+
+      expect(mockOnPageChange).toHaveBeenCalledWith(4);
+      expect(mockOnPageChange).toHaveBeenCalledTimes(1);
+    });
+
+    it("calls onPageChange when next button is clicked", async () => {
+      const user = userEvent.setup();
+      render(<TablePagination {...defaultProps} currentPage={5} />);
+
+      await user.click(screen.getByTestId("table-pagination-next"));
+
+      expect(mockOnPageChange).toHaveBeenCalledWith(6);
+      expect(mockOnPageChange).toHaveBeenCalledTimes(1);
+    });
+
+    it("has correct aria-labels for navigation buttons", () => {
+      render(<TablePagination {...defaultProps} />);
+
+      expect(screen.getByTestId("table-pagination-previous")).toHaveAttribute(
+        "aria-label",
+        "Go to previous page",
+      );
+      expect(screen.getByTestId("table-pagination-next")).toHaveAttribute(
+        "aria-label",
+        "Go to next page",
+      );
+    });
+  });
+
+  describe("Page Number Display Logic", () => {
+    it("shows all pages when totalPages is 6 or less", () => {
+      render(<TablePagination {...defaultProps} totalPages={6} />);
+
+      for (let i = 1; i <= 6; i++) {
+        expect(
+          screen.getByTestId(`table-pagination-page-${i}`),
+        ).toBeInTheDocument();
+      }
+
+      // Should not show ellipsis
+      expect(
+        screen.queryByTestId(/table-pagination-ellipsis/),
+      ).not.toBeInTheDocument();
+    });
+
+    it("shows all pages when totalPages is less than 6", () => {
+      render(<TablePagination {...defaultProps} totalPages={4} />);
+
+      for (let i = 1; i <= 4; i++) {
+        expect(
+          screen.getByTestId(`table-pagination-page-${i}`),
+        ).toBeInTheDocument();
+      }
+
+      expect(
+        screen.queryByTestId(/table-pagination-ellipsis/),
+      ).not.toBeInTheDocument();
+    });
+
+    it("shows first 5 pages + ellipsis when on page 1", () => {
+      render(
+        <TablePagination {...defaultProps} currentPage={1} totalPages={20} />,
+      );
+
+      // Should show pages 1-5
+      for (let i = 1; i <= 5; i++) {
+        expect(
+          screen.getByTestId(`table-pagination-page-${i}`),
+        ).toBeInTheDocument();
+      }
+
+      // Should show ellipsis
+      expect(
+        screen.getByTestId("table-pagination-ellipsis-5"),
+      ).toBeInTheDocument();
+
+      // Should not show page 6 or beyond
+      expect(
+        screen.queryByTestId("table-pagination-page-6"),
+      ).not.toBeInTheDocument();
+    });
+
+    it("shows first 5 pages + ellipsis when on page 5", () => {
+      render(
+        <TablePagination {...defaultProps} currentPage={5} totalPages={20} />,
+      );
+
+      for (let i = 1; i <= 5; i++) {
+        expect(
+          screen.getByTestId(`table-pagination-page-${i}`),
+        ).toBeInTheDocument();
+      }
+
+      expect(
+        screen.getByTestId("table-pagination-ellipsis-5"),
+      ).toBeInTheDocument();
+    });
+
+    it("shows 5 pages + ellipsis when in middle range", () => {
+      render(
+        <TablePagination {...defaultProps} currentPage={10} totalPages={20} />,
+      );
+
+      // Should show pages 9-13 (currentPage - 1 to currentPage + 3)
+      for (let i = 9; i <= 13; i++) {
+        expect(
+          screen.getByTestId(`table-pagination-page-${i}`),
+        ).toBeInTheDocument();
+      }
+
+      expect(
+        screen.getByTestId("table-pagination-ellipsis-5"),
+      ).toBeInTheDocument();
+    });
+
+    it("shows last 6 pages without ellipsis when near the end", () => {
+      render(
+        <TablePagination {...defaultProps} currentPage={18} totalPages={20} />,
+      );
+
+      // Should show pages 15-20 (last 6 pages)
+      for (let i = 15; i <= 20; i++) {
+        expect(
+          screen.getByTestId(`table-pagination-page-${i}`),
+        ).toBeInTheDocument();
+      }
+
+      // Should not show ellipsis
+      expect(
+        screen.queryByTestId(/table-pagination-ellipsis/),
+      ).not.toBeInTheDocument();
+    });
+
+    it("shows last 6 pages when on last page", () => {
+      render(
+        <TablePagination {...defaultProps} currentPage={20} totalPages={20} />,
+      );
+
+      for (let i = 15; i <= 20; i++) {
+        expect(
+          screen.getByTestId(`table-pagination-page-${i}`),
+        ).toBeInTheDocument();
+      }
+
+      expect(
+        screen.queryByTestId(/table-pagination-ellipsis/),
+      ).not.toBeInTheDocument();
+    });
+
+    it("renders single page correctly", () => {
+      render(
+        <TablePagination
+          {...defaultProps}
+          currentPage={1}
+          totalPages={1}
+          totalResults={5}
+        />,
+      );
+
+      expect(screen.getByTestId("table-pagination-page-1")).toBeInTheDocument();
+      expect(
+        screen.queryByTestId(/table-pagination-ellipsis/),
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  describe("Page Selection", () => {
+    it("calls onPageChange when page number is clicked", async () => {
+      const user = userEvent.setup();
+      render(<TablePagination {...defaultProps} currentPage={1} />);
+
+      await user.click(screen.getByTestId("table-pagination-page-3"));
+
+      expect(mockOnPageChange).toHaveBeenCalledWith(3);
+      expect(mockOnPageChange).toHaveBeenCalledTimes(1);
+    });
+
+    it("applies active styling to current page", () => {
+      render(<TablePagination {...defaultProps} currentPage={5} />);
+
+      const currentPageButton = screen.getByTestId("table-pagination-page-5");
+      expect(currentPageButton).toHaveClass("bg-foreground", "text-background");
+    });
+
+    it("applies hover styling to non-current pages", () => {
+      render(<TablePagination {...defaultProps} currentPage={5} />);
+
+      const nonCurrentPageButton = screen.getByTestId(
+        "table-pagination-page-3",
+      );
+      expect(nonCurrentPageButton).toHaveClass(
+        "text-foreground",
+        "hover:bg-accent",
+      );
+    });
+
+    it("displays correct page numbers", () => {
+      render(
+        <TablePagination {...defaultProps} currentPage={1} totalPages={6} />,
+      );
+
+      for (let i = 1; i <= 6; i++) {
+        const pageButton = screen.getByTestId(`table-pagination-page-${i}`);
+        expect(pageButton).toHaveTextContent(i.toString());
+      }
+    });
+  });
+
+  describe("Page Size Selection", () => {
+    it("renders page size selector", () => {
+      render(<TablePagination {...defaultProps} />);
+
+      expect(
+        screen.getByTestId("table-pagination-page-size"),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByTestId("table-pagination-page-size-trigger"),
+      ).toBeInTheDocument();
+    });
+
+    it("displays 'Per page' label", () => {
+      render(<TablePagination {...defaultProps} />);
+
+      expect(screen.getByText("Per page")).toBeInTheDocument();
+    });
+
+    it("renders default page size options", async () => {
+      const user = userEvent.setup();
+      render(<TablePagination {...defaultProps} />);
+
+      await user.click(
+        screen.getByTestId("table-pagination-page-size-trigger"),
+      );
+
+      const defaultOptions = [10, 20, 50, 100];
+      for (const size of defaultOptions) {
+        expect(
+          screen.getByTestId(`table-pagination-page-size-option-${size}`),
+        ).toBeInTheDocument();
+      }
+    });
+
+    it("renders custom page size options", async () => {
+      const user = userEvent.setup();
+      const customOptions = [25, 50, 75, 150];
+
+      render(
+        <TablePagination {...defaultProps} pageSizeOptions={customOptions} />,
+      );
+
+      await user.click(
+        screen.getByTestId("table-pagination-page-size-trigger"),
+      );
+
+      for (const size of customOptions) {
+        expect(
+          screen.getByTestId(`table-pagination-page-size-option-${size}`),
+        ).toBeInTheDocument();
+      }
+    });
+
+    it("displays current page size value", async () => {
+      const user = userEvent.setup();
+      render(<TablePagination {...defaultProps} pageSize={20} />);
+
+      await user.click(
+        screen.getByTestId("table-pagination-page-size-trigger"),
+      );
+
+      // The trigger should display the current value
+      const content = screen.getByTestId("table-pagination-page-size-content");
+      expect(content).toBeInTheDocument();
+    });
+
+    it("calls onPageSizeChange when selecting a different page size", async () => {
+      const user = userEvent.setup();
+      render(<TablePagination {...defaultProps} pageSize={10} />);
+
+      await user.click(
+        screen.getByTestId("table-pagination-page-size-trigger"),
+      );
+      await user.click(
+        screen.getByTestId("table-pagination-page-size-option-20"),
+      );
+
+      expect(mockOnPageSizeChange).toHaveBeenCalledWith(20);
+      expect(mockOnPageSizeChange).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("Edge Cases", () => {
+    it("handles first page with pageSize 1", () => {
+      render(
+        <TablePagination
+          {...defaultProps}
+          currentPage={1}
+          pageSize={1}
+          totalResults={100}
+          totalPages={100}
+        />,
+      );
+
+      expect(
+        screen.getByTestId("table-pagination-results-info"),
+      ).toHaveTextContent("1-1 of 100 results");
+    });
+
+    it("handles last page with partial results", () => {
+      render(
+        <TablePagination
+          {...defaultProps}
+          currentPage={11}
+          pageSize={10}
+          totalResults={103}
+          totalPages={11}
+        />,
+      );
+
+      expect(
+        screen.getByTestId("table-pagination-results-info"),
+      ).toHaveTextContent("101-103 of 103 results");
+    });
+
+    it("handles very large datasets", () => {
+      render(
+        <TablePagination
+          {...defaultProps}
+          currentPage={50}
+          pageSize={100}
+          totalResults={10000}
+          totalPages={100}
+        />,
+      );
+
+      expect(
+        screen.getByTestId("table-pagination-results-info"),
+      ).toHaveTextContent("4901-5000 of 10000 results");
+    });
+
+    it("handles single result", () => {
+      render(
+        <TablePagination
+          {...defaultProps}
+          currentPage={1}
+          pageSize={10}
+          totalResults={1}
+          totalPages={1}
+        />,
+      );
+
+      expect(
+        screen.getByTestId("table-pagination-results-info"),
+      ).toHaveTextContent("1-1 of 1 results");
+    });
+
+    it("handles exactly one full page", () => {
+      render(
+        <TablePagination
+          {...defaultProps}
+          currentPage={1}
+          pageSize={10}
+          totalResults={10}
+          totalPages={1}
+        />,
+      );
+
+      expect(
+        screen.getByTestId("table-pagination-results-info"),
+      ).toHaveTextContent("1-10 of 10 results");
+      expect(screen.getByTestId("table-pagination-previous")).toBeDisabled();
+      expect(screen.getByTestId("table-pagination-next")).toBeDisabled();
+    });
+
+    it("custom testId propagates to all sub-elements", async () => {
+      const user = userEvent.setup();
+      render(
+        <TablePagination
+          {...defaultProps}
+          testId="custom"
+          currentPage={1}
+          totalPages={10}
+        />,
+      );
+
+      expect(screen.getByTestId("custom")).toBeInTheDocument();
+      expect(screen.getByTestId("custom-results-info")).toBeInTheDocument();
+      expect(screen.getByTestId("custom-controls")).toBeInTheDocument();
+      expect(screen.getByTestId("custom-previous")).toBeInTheDocument();
+      expect(screen.getByTestId("custom-next")).toBeInTheDocument();
+      expect(screen.getByTestId("custom-page-1")).toBeInTheDocument();
+      expect(screen.getByTestId("custom-page-size")).toBeInTheDocument();
+      expect(
+        screen.getByTestId("custom-page-size-trigger"),
+      ).toBeInTheDocument();
+
+      await user.click(screen.getByTestId("custom-page-size-trigger"));
+
+      expect(
+        screen.getByTestId("custom-page-size-content"),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByTestId("custom-page-size-option-10"),
+      ).toBeInTheDocument();
+    });
+
+    it("handles boundary transition from page 5 to page 6", () => {
+      render(
+        <TablePagination {...defaultProps} currentPage={6} totalPages={20} />,
+      );
+
+      // Should now be in middle range showing 5-9 + ellipsis
+      for (let i = 5; i <= 9; i++) {
+        expect(
+          screen.getByTestId(`table-pagination-page-${i}`),
+        ).toBeInTheDocument();
+      }
+
+      expect(
+        screen.getByTestId("table-pagination-ellipsis-5"),
+      ).toBeInTheDocument();
+    });
+
+    it("handles boundary transition to last 6 pages", () => {
+      render(
+        <TablePagination {...defaultProps} currentPage={16} totalPages={20} />,
+      );
+
+      // Should show last 6 pages (15-20)
+      for (let i = 15; i <= 20; i++) {
+        expect(
+          screen.getByTestId(`table-pagination-page-${i}`),
+        ).toBeInTheDocument();
+      }
+
+      expect(
+        screen.queryByTestId(/table-pagination-ellipsis/),
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  describe("Integration Tests", () => {
+    it("navigates through pages correctly", async () => {
+      const user = userEvent.setup();
+      const { rerender } = render(
+        <TablePagination {...defaultProps} currentPage={1} totalPages={5} />,
+      );
+
+      // Click next
+      await user.click(screen.getByTestId("table-pagination-next"));
+      expect(mockOnPageChange).toHaveBeenCalledWith(2);
+
+      // Simulate page change
+      rerender(
+        <TablePagination {...defaultProps} currentPage={2} totalPages={5} />,
+      );
+
+      // Click page 4
+      await user.click(screen.getByTestId("table-pagination-page-4"));
+      expect(mockOnPageChange).toHaveBeenCalledWith(4);
+
+      // Simulate page change
+      rerender(
+        <TablePagination {...defaultProps} currentPage={4} totalPages={5} />,
+      );
+
+      // Click previous
+      await user.click(screen.getByTestId("table-pagination-previous"));
+      expect(mockOnPageChange).toHaveBeenCalledWith(3);
+    });
+
+    it("updates results display when page size changes", () => {
+      const { rerender } = render(
+        <TablePagination
+          {...defaultProps}
+          currentPage={1}
+          pageSize={10}
+          totalResults={100}
+        />,
+      );
+
+      expect(
+        screen.getByTestId("table-pagination-results-info"),
+      ).toHaveTextContent("1-10 of 100 results");
+
+      rerender(
+        <TablePagination
+          {...defaultProps}
+          currentPage={1}
+          pageSize={20}
+          totalResults={100}
+        />,
+      );
+
+      expect(
+        screen.getByTestId("table-pagination-results-info"),
+      ).toHaveTextContent("1-20 of 100 results");
+    });
+  });
+});

--- a/spa/src/components/table/table-pagination/TablePagination.tsx
+++ b/spa/src/components/table/table-pagination/TablePagination.tsx
@@ -1,0 +1,184 @@
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { ChevronLeft, ChevronRight, MoreHorizontal } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+export interface TablePaginationProps {
+  currentPage: number;
+  totalPages: number;
+  totalResults: number;
+  pageSize: number;
+  onPageChange: (page: number) => void;
+  onPageSizeChange: (pageSize: number) => void;
+  pageSizeOptions?: number[];
+  className?: string;
+  testId?: string;
+}
+
+export function TablePagination({
+  currentPage,
+  totalPages,
+  totalResults,
+  pageSize,
+  onPageChange,
+  onPageSizeChange,
+  pageSizeOptions = [10, 20, 50, 100],
+  className,
+  testId = "table-pagination",
+}: TablePaginationProps) {
+  const startResult = (currentPage - 1) * pageSize + 1;
+  const endResult = Math.min(currentPage * pageSize, totalResults);
+
+  // Generate page numbers to display
+  const getPageNumbers = () => {
+    const pages: (number | "ellipsis")[] = [];
+
+    if (totalPages <= 6) {
+      // Show all pages if 6 or less
+      for (let i = 1; i <= totalPages; i++) {
+        pages.push(i);
+      }
+    } else {
+      // More than 6 pages - always show exactly 6 elements
+      // Determine if we're near the end (last 6 pages)
+      if (currentPage > totalPages - 5) {
+        // Near the end - show last 6 pages (no ellipsis)
+        for (let i = totalPages - 5; i <= totalPages; i++) {
+          pages.push(i);
+        }
+      } else if (currentPage <= 5) {
+        // Near the start - show first 5 pages + ellipsis
+        for (let i = 1; i <= 5; i++) {
+          pages.push(i);
+        }
+        pages.push("ellipsis");
+      } else {
+        // In the middle - show 5 pages starting from (currentPage - 1) + ellipsis
+        const start = currentPage - 1;
+        for (let i = start; i < start + 5; i++) {
+          pages.push(i);
+        }
+        pages.push("ellipsis");
+      }
+    }
+
+    return pages;
+  };
+
+  return (
+    <div
+      className={cn("flex items-center justify-between text-base", className)}
+      data-testid={testId}
+    >
+      {/* Results info */}
+      <div
+        className="text-foreground text-base font-normal leading-snug flex-1"
+        data-testid={`${testId}-results-info`}
+      >
+        {startResult}-{endResult} of {totalResults} results
+      </div>
+
+      {/* Pagination controls */}
+      <div
+        className="flex items-center gap-3"
+        data-testid={`${testId}-controls`}
+      >
+        {/* Previous button */}
+        <button
+          onClick={() => onPageChange(currentPage - 1)}
+          disabled={currentPage === 1}
+          className={cn(
+            "inline-flex items-center justify-center",
+            currentPage === 1
+              ? "opacity-50 cursor-not-allowed"
+              : "cursor-pointer",
+          )}
+          aria-label="Go to previous page"
+          data-testid={`${testId}-previous`}
+        >
+          <ChevronLeft className="w-6 h-6" />
+        </button>
+
+        {/* Page numbers */}
+        {getPageNumbers().map((page, index) => (
+          <div key={index}>
+            {page === "ellipsis" ? (
+              <div
+                className="w-8 h-8 inline-flex items-center justify-center"
+                data-testid={`${testId}-ellipsis-${index}`}
+              >
+                <MoreHorizontal className="w-6 h-6" />
+              </div>
+            ) : (
+              <button
+                onClick={() => onPageChange(page)}
+                className={cn(
+                  "w-8 h-8 px-1 rounded inline-flex flex-col justify-center items-center gap-2.5 overflow-hidden text-base font-normal leading-snug",
+                  page === currentPage
+                    ? "bg-foreground text-background"
+                    : "text-foreground hover:bg-accent",
+                )}
+                data-testid={`${testId}-page-${page}`}
+              >
+                {page}
+              </button>
+            )}
+          </div>
+        ))}
+
+        {/* Next button */}
+        <button
+          onClick={() => onPageChange(currentPage + 1)}
+          disabled={currentPage === totalPages}
+          className={cn(
+            "inline-flex items-center justify-center",
+            currentPage === totalPages
+              ? "opacity-50 cursor-not-allowed"
+              : "cursor-pointer",
+          )}
+          aria-label="Go to next page"
+          data-testid={`${testId}-next`}
+        >
+          <ChevronRight className="w-6 h-6" />
+        </button>
+      </div>
+
+      {/* Per page selector */}
+      <div
+        className="flex items-center gap-2 flex-1 justify-end"
+        data-testid={`${testId}-page-size`}
+      >
+        <span className="text-foreground text-base font-normal leading-snug">
+          Per page
+        </span>
+        <Select
+          value={pageSize.toString()}
+          onValueChange={(value) => onPageSizeChange(Number(value))}
+        >
+          <SelectTrigger
+            className="w-20 focus:ring-0 focus:ring-offset-0 border border-input shadow-none [&_svg]:opacity-100 [&_svg]:text-neutral-700 dark:[&_svg]:text-neutral-400 [&_svg]:stroke-[2.5]"
+            data-testid={`${testId}-page-size-trigger`}
+          >
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent data-testid={`${testId}-page-size-content`}>
+            {pageSizeOptions.map((size) => (
+              <SelectItem
+                key={size}
+                value={size.toString()}
+                data-testid={`${testId}-page-size-option-${size}`}
+              >
+                {size}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+    </div>
+  );
+}

--- a/spa/src/components/table/table-pagination/index.ts
+++ b/spa/src/components/table/table-pagination/index.ts
@@ -1,0 +1,2 @@
+export { TablePagination } from "./TablePagination";
+export type { TablePaginationProps } from "./TablePagination";

--- a/spa/src/components/ui/pagination.tsx
+++ b/spa/src/components/ui/pagination.tsx
@@ -1,0 +1,117 @@
+import * as React from "react";
+import { ChevronLeft, ChevronRight, MoreHorizontal } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+import { ButtonProps, buttonVariants } from "@/components/ui/button";
+
+const Pagination = ({ className, ...props }: React.ComponentProps<"nav">) => (
+  <nav
+    role="navigation"
+    aria-label="pagination"
+    className={cn("mx-auto flex w-full justify-center", className)}
+    {...props}
+  />
+);
+Pagination.displayName = "Pagination";
+
+const PaginationContent = React.forwardRef<
+  HTMLUListElement,
+  React.ComponentProps<"ul">
+>(({ className, ...props }, ref) => (
+  <ul
+    ref={ref}
+    className={cn("flex flex-row items-center gap-1", className)}
+    {...props}
+  />
+));
+PaginationContent.displayName = "PaginationContent";
+
+const PaginationItem = React.forwardRef<
+  HTMLLIElement,
+  React.ComponentProps<"li">
+>(({ className, ...props }, ref) => (
+  <li ref={ref} className={cn("", className)} {...props} />
+));
+PaginationItem.displayName = "PaginationItem";
+
+type PaginationLinkProps = {
+  isActive?: boolean;
+} & Pick<ButtonProps, "size"> &
+  React.ComponentProps<"a">;
+
+const PaginationLink = ({
+  className,
+  isActive,
+  size = "icon",
+  ...props
+}: PaginationLinkProps) => (
+  <a
+    aria-current={isActive ? "page" : undefined}
+    className={cn(
+      buttonVariants({
+        variant: isActive ? "outline" : "ghost",
+        size,
+      }),
+      className,
+    )}
+    {...props}
+  />
+);
+PaginationLink.displayName = "PaginationLink";
+
+const PaginationPrevious = ({
+  className,
+  ...props
+}: React.ComponentProps<typeof PaginationLink>) => (
+  <PaginationLink
+    aria-label="Go to previous page"
+    size="default"
+    className={cn("gap-1 pl-2.5", className)}
+    {...props}
+  >
+    <ChevronLeft className="h-4 w-4" />
+    <span>Previous</span>
+  </PaginationLink>
+);
+PaginationPrevious.displayName = "PaginationPrevious";
+
+const PaginationNext = ({
+  className,
+  ...props
+}: React.ComponentProps<typeof PaginationLink>) => (
+  <PaginationLink
+    aria-label="Go to next page"
+    size="default"
+    className={cn("gap-1 pr-2.5", className)}
+    {...props}
+  >
+    <span>Next</span>
+    <ChevronRight className="h-4 w-4" />
+  </PaginationLink>
+);
+PaginationNext.displayName = "PaginationNext";
+
+const PaginationEllipsis = ({
+  className,
+  ...props
+}: React.ComponentProps<"span">) => (
+  <span
+    aria-hidden
+    className={cn("flex h-9 w-9 items-center justify-center", className)}
+    {...props}
+  >
+    <MoreHorizontal className="h-4 w-4" />
+    <span className="sr-only">More pages</span>
+  </span>
+);
+PaginationEllipsis.displayName = "PaginationEllipsis";
+
+export {
+  Pagination,
+  PaginationContent,
+  PaginationLink,
+  PaginationItem,
+  PaginationPrevious,
+  PaginationNext,
+  PaginationEllipsis,
+};

--- a/spa/src/components/ui/select.tsx
+++ b/spa/src/components/ui/select.tsx
@@ -1,0 +1,157 @@
+import * as React from "react";
+import * as SelectPrimitive from "@radix-ui/react-select";
+import { Check, ChevronDown, ChevronUp } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+
+const Select = SelectPrimitive.Root;
+
+const SelectGroup = SelectPrimitive.Group;
+
+const SelectValue = SelectPrimitive.Value;
+
+const SelectTrigger = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.Trigger>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Trigger>
+>(({ className, children, ...props }, ref) => (
+  <SelectPrimitive.Trigger
+    ref={ref}
+    className={cn(
+      "flex h-9 w-full items-center justify-between whitespace-nowrap rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-sm ring-offset-background data-[placeholder]:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-ring disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1",
+      className,
+    )}
+    {...props}
+  >
+    {children}
+    <SelectPrimitive.Icon asChild>
+      <ChevronDown className="h-4 w-4 opacity-50" />
+    </SelectPrimitive.Icon>
+  </SelectPrimitive.Trigger>
+));
+SelectTrigger.displayName = SelectPrimitive.Trigger.displayName;
+
+const SelectScrollUpButton = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.ScrollUpButton>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.ScrollUpButton>
+>(({ className, ...props }, ref) => (
+  <SelectPrimitive.ScrollUpButton
+    ref={ref}
+    className={cn(
+      "flex cursor-default items-center justify-center py-1",
+      className,
+    )}
+    {...props}
+  >
+    <ChevronUp className="h-4 w-4" />
+  </SelectPrimitive.ScrollUpButton>
+));
+SelectScrollUpButton.displayName = SelectPrimitive.ScrollUpButton.displayName;
+
+const SelectScrollDownButton = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.ScrollDownButton>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.ScrollDownButton>
+>(({ className, ...props }, ref) => (
+  <SelectPrimitive.ScrollDownButton
+    ref={ref}
+    className={cn(
+      "flex cursor-default items-center justify-center py-1",
+      className,
+    )}
+    {...props}
+  >
+    <ChevronDown className="h-4 w-4" />
+  </SelectPrimitive.ScrollDownButton>
+));
+SelectScrollDownButton.displayName =
+  SelectPrimitive.ScrollDownButton.displayName;
+
+const SelectContent = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Content>
+>(({ className, children, position = "popper", ...props }, ref) => (
+  <SelectPrimitive.Portal>
+    <SelectPrimitive.Content
+      ref={ref}
+      className={cn(
+        "relative z-50 max-h-[--radix-select-content-available-height] min-w-[8rem] overflow-y-auto overflow-x-hidden rounded-md border bg-popover text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-[--radix-select-content-transform-origin]",
+        position === "popper" &&
+          "data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1",
+        className,
+      )}
+      position={position}
+      {...props}
+    >
+      <SelectScrollUpButton />
+      <SelectPrimitive.Viewport
+        className={cn(
+          "p-1",
+          position === "popper" &&
+            "h-[var(--radix-select-trigger-height)] w-full min-w-[var(--radix-select-trigger-width)]",
+        )}
+      >
+        {children}
+      </SelectPrimitive.Viewport>
+      <SelectScrollDownButton />
+    </SelectPrimitive.Content>
+  </SelectPrimitive.Portal>
+));
+SelectContent.displayName = SelectPrimitive.Content.displayName;
+
+const SelectLabel = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.Label>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Label>
+>(({ className, ...props }, ref) => (
+  <SelectPrimitive.Label
+    ref={ref}
+    className={cn("px-2 py-1.5 text-sm font-semibold", className)}
+    {...props}
+  />
+));
+SelectLabel.displayName = SelectPrimitive.Label.displayName;
+
+const SelectItem = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.Item>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Item>
+>(({ className, children, ...props }, ref) => (
+  <SelectPrimitive.Item
+    ref={ref}
+    className={cn(
+      "relative flex w-full cursor-default select-none items-center rounded-sm py-1.5 pl-2 pr-8 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      className,
+    )}
+    {...props}
+  >
+    <span className="absolute right-2 flex h-3.5 w-3.5 items-center justify-center">
+      <SelectPrimitive.ItemIndicator>
+        <Check className="h-4 w-4" />
+      </SelectPrimitive.ItemIndicator>
+    </span>
+    <SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>
+  </SelectPrimitive.Item>
+));
+SelectItem.displayName = SelectPrimitive.Item.displayName;
+
+const SelectSeparator = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.Separator>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Separator>
+>(({ className, ...props }, ref) => (
+  <SelectPrimitive.Separator
+    ref={ref}
+    className={cn("-mx-1 my-1 h-px bg-muted", className)}
+    {...props}
+  />
+));
+SelectSeparator.displayName = SelectPrimitive.Separator.displayName;
+
+export {
+  Select,
+  SelectGroup,
+  SelectValue,
+  SelectTrigger,
+  SelectContent,
+  SelectLabel,
+  SelectItem,
+  SelectSeparator,
+  SelectScrollUpButton,
+  SelectScrollDownButton,
+};

--- a/spa/vitest.setup.ts
+++ b/spa/vitest.setup.ts
@@ -1,1 +1,21 @@
 import "@testing-library/jest-dom";
+
+// Polyfill for Radix UI pointer capture events
+if (!Element.prototype.hasPointerCapture) {
+  Element.prototype.hasPointerCapture = function () {
+    return false;
+  };
+}
+
+if (!Element.prototype.setPointerCapture) {
+  Element.prototype.setPointerCapture = function () {};
+}
+
+if (!Element.prototype.releasePointerCapture) {
+  Element.prototype.releasePointerCapture = function () {};
+}
+
+// Polyfill for scrollIntoView
+if (!Element.prototype.scrollIntoView) {
+  Element.prototype.scrollIntoView = function () {};
+}


### PR DESCRIPTION
This PR adds a table pagination component based on the high-fidelity design, stories and unit tests. It also includes some polyfills.

### Unit Tests
<img width="1703" height="1005" alt="Screenshot 2025-10-13 at 7 13 19 pm" src="https://github.com/user-attachments/assets/ebfea53b-731f-4f70-9dea-222dc8eb5f65" />


### Documentation
<img width="1674" height="1155" alt="Screenshot 2025-10-13 at 7 01 15 pm" src="https://github.com/user-attachments/assets/3634799f-28ad-464f-8fea-fd118a9d919e" />

### Light Mode
<img width="1674" height="1155" alt="Screenshot 2025-10-13 at 7 01 44 pm" src="https://github.com/user-attachments/assets/ec7ae027-6d41-4cbf-9374-fb6a55eac50b" />
<img width="1674" height="1155" alt="Screenshot 2025-10-13 at 7 02 47 pm" src="https://github.com/user-attachments/assets/624fe00f-7970-4556-955b-cadf3fa39b49" />
<img width="1674" height="1155" alt="Screenshot 2025-10-13 at 7 02 52 pm" src="https://github.com/user-attachments/assets/07628f8a-e204-4ed4-b967-a5323b8a0a95" />
<img width="1674" height="1155" alt="Screenshot 2025-10-13 at 7 02 55 pm" src="https://github.com/user-attachments/assets/0de64cbd-a2af-4c73-a5ee-c8237b8849fb" />
<img width="1674" height="1155" alt="Screenshot 2025-10-13 at 7 03 11 pm" src="https://github.com/user-attachments/assets/9c15f1b8-b88e-4159-b13a-994b7b207d20" />


### Dark Mode
<img width="1674" height="1155" alt="Screenshot 2025-10-13 at 7 01 49 pm" src="https://github.com/user-attachments/assets/0fdce2fe-f659-46ab-ba04-e41a45d2f3b6" />
<img width="1674" height="1155" alt="Screenshot 2025-10-13 at 7 03 19 pm" src="https://github.com/user-attachments/assets/f6017278-b8ca-438f-a571-51e0c124bb58" />

