### PR TITLE
headers is not a function - fixes #46

### DIFF
--- a/spa/src/services/api.ts
+++ b/spa/src/services/api.ts
@@ -25,7 +25,7 @@ class ApiService {
       const url = `${API_BASE_URL}${endpoint}`;
 
       // Always include Authorization header if we have a token
-      const headers: any = {
+      const headers: Record<string, string> = {
         ...(token && { Authorization: `Bearer ${token}` }),
       };
 
@@ -36,7 +36,7 @@ class ApiService {
 
       // Set default Content-Type for JSON requests, but skip for FormData
       const isFormData = options.body instanceof FormData;
-      if (!headers("Content-Type") && !isFormData) {
+      if (!headers["Content-Type"] && !isFormData) {
         headers["Content-Type"] = "application/json";
       }
 


### PR DESCRIPTION
The issue wasn't being picked up by the type checker because it was typed as `any`, but when set correctly, the type checker also points out the same error we were seeing in #46 .

This change fixes that, and I've confirmed I can then upload a file.