### PR TITLE
feat: add confirmation dialog

### DIFF
--- a/spa/package-lock.json
+++ b/spa/package-lock.json
@@ -8,6 +8,7 @@
       "name": "stuf-spa",
       "version": "0.1.0",
       "dependencies": {
+        "@radix-ui/react-alert-dialog": "^1.1.15",
         "@radix-ui/react-avatar": "^1.1.10",
         "@radix-ui/react-checkbox": "^1.3.3",
         "@radix-ui/react-dropdown-menu": "^2.1.16",
@@ -1524,6 +1525,34 @@
       "integrity": "sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==",
       "license": "MIT"
     },
+    "node_modules/@radix-ui/react-alert-dialog": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-alert-dialog/-/react-alert-dialog-1.1.15.tgz",
+      "integrity": "sha512-oTVLkEw5GpdRe29BqJ0LSDFWI3qu0vR1M0mUkOQWDIUnY/QIkLpgDMWuKxP94c2NAC2LGcgVhG1ImF3jkZ5wXw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-dialog": "1.1.15",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-arrow": {
       "version": "1.1.7",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-arrow/-/react-arrow-1.1.7.tgz",
@@ -1656,6 +1685,42 @@
       },
       "peerDependenciesMeta": {
         "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dialog": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dialog/-/react-dialog-1.1.15.tgz",
+      "integrity": "sha512-TCglVRtzlffRNxRMEyR36DGBLJpeusFcgMVD9PZEzAKnUs1lKCgX5u9BmC2Yg+LL9MgZDugFFs1Vl+Jp4t/PGw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-dismissable-layer": "1.1.11",
+        "@radix-ui/react-focus-guards": "1.1.3",
+        "@radix-ui/react-focus-scope": "1.1.7",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-portal": "1.1.9",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-slot": "1.2.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "aria-hidden": "^1.2.4",
+        "react-remove-scroll": "^2.6.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
           "optional": true
         }
       }

--- a/spa/package.json
+++ b/spa/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
+    "@radix-ui/react-alert-dialog": "^1.1.15",
     "@radix-ui/react-avatar": "^1.1.10",
     "@radix-ui/react-checkbox": "^1.3.3",
     "@radix-ui/react-dropdown-menu": "^2.1.16",

--- a/spa/src/components/dialogs/ConfirmDialog.stories.tsx
+++ b/spa/src/components/dialogs/ConfirmDialog.stories.tsx
@@ -1,0 +1,293 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { ConfirmDialog } from "./ConfirmDialog";
+import { useState } from "react";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+
+const meta = {
+  title: "Components/Dialogs/ConfirmDialog",
+  component: ConfirmDialog,
+  parameters: {
+    layout: "centered",
+    design: {
+      type: "figma",
+      url: "https://www.figma.com/design/SQOopW8mFNB8TLQSZvOySp/RBTP-UI?node-id=691-7584&m=dev",
+    },
+  },
+  tags: ["autodocs"],
+  decorators: [
+    (Story) => (
+      <div className="min-h-screen min-w-screen flex items-center justify-center bg-background p-4">
+        <Story />
+      </div>
+    ),
+  ],
+  argTypes: {
+    open: {
+      control: "boolean",
+      description: "Controls whether the dialog is open or closed",
+    },
+    title: {
+      control: "text",
+      description: "The main title of the dialog",
+    },
+    description: {
+      control: "text",
+      description: "Optional description text displayed below the title",
+    },
+    confirmText: {
+      control: "text",
+      description: "Text for the confirm button",
+    },
+    cancelText: {
+      control: "text",
+      description: "Text for the cancel button",
+    },
+    dangerAlert: {
+      control: "object",
+      description:
+        "Optional danger alert object with a message property for destructive actions",
+    },
+    children: {
+      control: false,
+      description: "Optional custom content (e.g., form fields, selects)",
+    },
+    isLoading: {
+      control: "boolean",
+      description: "Shows loading spinner and disables buttons when true",
+    },
+    loadingText: {
+      control: "text",
+      description: "Text to display on confirm button during loading state",
+    },
+    onConfirm: {
+      action: "confirmed",
+      description: "Callback function when user confirms",
+    },
+    onCancel: {
+      action: "cancelled",
+      description: "Callback function when user cancels",
+    },
+  },
+} satisfies Meta<typeof ConfirmDialog>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+// Wrapper component to handle state for interactive stories
+function ConfirmDialogWrapper({
+  title,
+  description,
+  confirmText,
+  cancelText,
+  dangerAlert,
+  children,
+  loadingText,
+  simulateAsync = false,
+  onConfirmCallback,
+  onCancelCallback,
+}: {
+  title: string;
+  description?: string;
+  confirmText?: string;
+  cancelText?: string;
+  dangerAlert?: { message: string };
+  children?: React.ReactNode;
+  loadingText?: string;
+  simulateAsync?: boolean;
+  onConfirmCallback?: () => void;
+  onCancelCallback?: () => void;
+}) {
+  const [open, setOpen] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
+
+  const handleConfirm = async () => {
+    if (simulateAsync) {
+      setIsLoading(true);
+      // Simulate async operation (e.g., API call)
+      await new Promise((resolve) => setTimeout(resolve, 3000));
+      console.log("Operation completed");
+      setIsLoading(false);
+    } else {
+      console.log("Confirmed");
+    }
+
+    if (onConfirmCallback) {
+      onConfirmCallback();
+    }
+
+    setOpen(false);
+  };
+
+  const handleCancel = () => {
+    console.log("Cancelled");
+    setIsLoading(false);
+
+    if (onCancelCallback) {
+      onCancelCallback();
+    }
+
+    setOpen(false);
+  };
+
+  return (
+    <div>
+      <button
+        onClick={() => setOpen(true)}
+        className="px-4 py-2 bg-primary-mid text-primary-text rounded-md font-medium hover:opacity-90 transition-opacity"
+      >
+        Open Dialog
+      </button>
+      <ConfirmDialog
+        open={open}
+        title={title}
+        description={description}
+        confirmText={confirmText}
+        cancelText={cancelText}
+        dangerAlert={dangerAlert}
+        isLoading={isLoading}
+        loadingText={loadingText}
+        onConfirm={handleConfirm}
+        onCancel={handleCancel}
+      >
+        {children}
+      </ConfirmDialog>
+    </div>
+  );
+}
+
+// Default variant
+export const Default: Story = {
+  args: {} as any,
+  render: () => (
+    <ConfirmDialogWrapper
+      title="Are you sure?"
+      description="This action cannot be undone."
+      confirmText="Continue"
+      cancelText="Cancel"
+    />
+  ),
+};
+
+// File Delete
+export const DeleteFile: Story = {
+  args: {} as any,
+  render: () => (
+    <ConfirmDialogWrapper
+      title="Delete file"
+      description="Are you sure you want to delete this file? This action can't be undone."
+      confirmText="Delete file"
+      cancelText="Cancel"
+    />
+  ),
+};
+
+// Archive File
+export const ArchiveFile: Story = {
+  args: {} as any,
+  render: () => (
+    <ConfirmDialogWrapper
+      title="Archive file"
+      description='Are you sure you want to archive "report.xlsx"?'
+      confirmText="Archive"
+      cancelText="Cancel"
+    />
+  ),
+};
+
+// With Long Description
+export const WithLongDescription: Story = {
+  args: {} as any,
+  render: () => (
+    <ConfirmDialogWrapper
+      title="Delete file"
+      description="This action will permanently delete all selected files and their associated metadata. This includes any comments, tags, and version history."
+      confirmText="Delete file"
+      cancelText="Cancel"
+    />
+  ),
+};
+
+// Destructive action with danger alert
+export const DestructiveWithDangerAlert: Story = {
+  args: {} as any,
+  render: () => (
+    <ConfirmDialogWrapper
+      title="Delete collection"
+      description="This will permanently delete the collection and all files within it."
+      confirmText="Delete collection"
+      cancelText="Cancel"
+      dangerAlert={{
+        message:
+          "Warning: This action cannot be undone. All data will be permanently lost.",
+      }}
+    />
+  ),
+};
+
+// With loading state
+export const WithLoadingState: Story = {
+  args: {} as any,
+  render: () => (
+    <ConfirmDialogWrapper
+      title="Process files"
+      description="This will process all selected files. This may take a few moments."
+      confirmText="Process"
+      cancelText="Cancel"
+      loadingText="Processing..."
+      simulateAsync={true}
+    />
+  ),
+};
+
+// With child component (select dropdown)
+export const WithSelectChild: Story = {
+  args: {} as any,
+  render: () => {
+    const [selectedCollection, setSelectedCollection] = useState("");
+
+    return (
+      <ConfirmDialogWrapper
+        title="Move file"
+        description="Select a collection to move this file to."
+        confirmText="Move"
+        cancelText="Cancel"
+        onConfirmCallback={() => {
+          console.log("Moving to collection:", selectedCollection);
+          setSelectedCollection("");
+        }}
+        onCancelCallback={() => {
+          setSelectedCollection("");
+        }}
+      >
+        <div className="self-stretch flex flex-col gap-2">
+          <label
+            htmlFor="collection-select"
+            className="text-foreground text-sm font-medium"
+          >
+            Destination collection
+          </label>
+          <Select
+            value={selectedCollection}
+            onValueChange={setSelectedCollection}
+          >
+            <SelectTrigger className="w-full">
+              <SelectValue placeholder="Select a collection..." />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="research">Research Data</SelectItem>
+              <SelectItem value="reports">Reports</SelectItem>
+              <SelectItem value="archive">Archive</SelectItem>
+              <SelectItem value="shared">Shared Files</SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
+      </ConfirmDialogWrapper>
+    );
+  },
+};

--- a/spa/src/components/dialogs/ConfirmDialog.test.tsx
+++ b/spa/src/components/dialogs/ConfirmDialog.test.tsx
@@ -1,0 +1,208 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { ConfirmDialog } from "./ConfirmDialog";
+
+describe("ConfirmDialog", () => {
+  const mockOnConfirm = vi.fn();
+  const mockOnCancel = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders with title and description", () => {
+    render(
+      <ConfirmDialog
+        open={true}
+        title="Delete file"
+        description="Are you sure you want to delete this file?"
+        onConfirm={mockOnConfirm}
+        onCancel={mockOnCancel}
+      />,
+    );
+
+    expect(screen.getByTestId("confirm-dialog-title")).toHaveTextContent(
+      "Delete file",
+    );
+    expect(screen.getByTestId("confirm-dialog-description")).toHaveTextContent(
+      "Are you sure you want to delete this file?",
+    );
+  });
+
+  it("renders with custom button text", () => {
+    render(
+      <ConfirmDialog
+        open={true}
+        title="Delete file"
+        description="Are you sure?"
+        confirmText="Delete"
+        cancelText="Go back"
+        onConfirm={mockOnConfirm}
+        onCancel={mockOnCancel}
+      />,
+    );
+
+    expect(screen.getByTestId("confirm-dialog-confirm")).toHaveTextContent(
+      "Delete",
+    );
+    expect(screen.getByTestId("confirm-dialog-cancel")).toHaveTextContent(
+      "Go back",
+    );
+  });
+
+  it("calls onConfirm when confirm button is clicked", () => {
+    render(
+      <ConfirmDialog
+        open={true}
+        title="Delete file"
+        description="Are you sure?"
+        confirmText="Delete"
+        onConfirm={mockOnConfirm}
+        onCancel={mockOnCancel}
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId("confirm-dialog-confirm"));
+    expect(mockOnConfirm).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls onCancel when cancel button is clicked", () => {
+    render(
+      <ConfirmDialog
+        open={true}
+        title="Delete file"
+        description="Are you sure?"
+        cancelText="Cancel"
+        onConfirm={mockOnConfirm}
+        onCancel={mockOnCancel}
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId("confirm-dialog-cancel"));
+    expect(mockOnCancel).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders danger alert when provided", () => {
+    render(
+      <ConfirmDialog
+        open={true}
+        title="Delete collection"
+        description="This will permanently delete the collection."
+        dangerAlert={{
+          message:
+            "All files will be deleted immediately and can't be retrieved.",
+        }}
+        onConfirm={mockOnConfirm}
+        onCancel={mockOnCancel}
+      />,
+    );
+
+    expect(screen.getByTestId("confirm-dialog-danger-alert")).toHaveTextContent(
+      "All files will be deleted immediately and can't be retrieved.",
+    );
+  });
+
+  it("renders custom children", () => {
+    render(
+      <ConfirmDialog
+        open={true}
+        title="Delete collection"
+        description="Are you sure you want to proceed?"
+        onConfirm={mockOnConfirm}
+        onCancel={mockOnCancel}
+      >
+        <div>Custom content here</div>
+      </ConfirmDialog>,
+    );
+
+    expect(screen.getByTestId("confirm-dialog-children")).toHaveTextContent(
+      "Custom content here",
+    );
+  });
+
+  it("renders without description", () => {
+    render(
+      <ConfirmDialog
+        open={true}
+        title="Delete collection"
+        onConfirm={mockOnConfirm}
+        onCancel={mockOnCancel}
+      />,
+    );
+
+    expect(screen.getByTestId("confirm-dialog-title")).toHaveTextContent(
+      "Delete collection",
+    );
+    expect(
+      screen.queryByTestId("confirm-dialog-description"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("does not render when closed", () => {
+    render(
+      <ConfirmDialog
+        open={false}
+        title="Delete file"
+        description="Are you sure?"
+        onConfirm={mockOnConfirm}
+        onCancel={mockOnCancel}
+      />,
+    );
+
+    expect(screen.queryByTestId("confirm-dialog")).not.toBeInTheDocument();
+  });
+
+  it("disables buttons when loading", () => {
+    render(
+      <ConfirmDialog
+        open={true}
+        title="Processing"
+        description="Please wait while we process your request."
+        isLoading={true}
+        onConfirm={mockOnConfirm}
+        onCancel={mockOnCancel}
+      />,
+    );
+
+    expect(screen.getByTestId("confirm-dialog-confirm")).toBeDisabled();
+    expect(screen.getByTestId("confirm-dialog-cancel")).toBeDisabled();
+  });
+
+  it("displays loading text when loading", () => {
+    render(
+      <ConfirmDialog
+        open={true}
+        title="Processing"
+        description="Please wait while we process your request."
+        confirmText="Submit"
+        isLoading={true}
+        loadingText="Submitting..."
+        onConfirm={mockOnConfirm}
+        onCancel={mockOnCancel}
+      />,
+    );
+
+    expect(screen.getByTestId("confirm-dialog-confirm")).toHaveTextContent(
+      "Submitting...",
+    );
+  });
+
+  it("displays default confirm text when not loading", () => {
+    render(
+      <ConfirmDialog
+        open={true}
+        title="Processing"
+        description="Please confirm your submission."
+        confirmText="Submit"
+        isLoading={false}
+        loadingText="Submitting..."
+        onConfirm={mockOnConfirm}
+        onCancel={mockOnCancel}
+      />,
+    );
+
+    expect(screen.getByTestId("confirm-dialog-confirm")).toHaveTextContent(
+      "Submit",
+    );
+  });
+});

--- a/spa/src/components/dialogs/ConfirmDialog.tsx
+++ b/spa/src/components/dialogs/ConfirmDialog.tsx
@@ -1,0 +1,133 @@
+import * as AlertDialogPrimitive from "@radix-ui/react-alert-dialog";
+import { AlertCircle, Loader2 } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+export interface ConfirmDialogProps {
+  open: boolean;
+  title: string;
+  description?: string;
+  confirmText?: string;
+  cancelText?: string;
+  dangerAlert?: {
+    message: string;
+  };
+  children?: React.ReactNode;
+  isLoading?: boolean;
+  loadingText?: string;
+  onConfirm: () => void | Promise<void>;
+  onCancel: () => void;
+}
+
+export function ConfirmDialog({
+  open,
+  title,
+  description,
+  confirmText = "Continue",
+  cancelText = "Cancel",
+  dangerAlert,
+  children,
+  isLoading = false,
+  loadingText,
+  onConfirm,
+  onCancel,
+}: ConfirmDialogProps) {
+  return (
+    <AlertDialogPrimitive.Root
+      open={open}
+      onOpenChange={(isOpen) => {
+        if (!isOpen) {
+          onCancel();
+        }
+      }}
+    >
+      <AlertDialogPrimitive.Portal>
+        <AlertDialogPrimitive.Overlay className="fixed inset-0 z-50 bg-black/80 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0" />
+        <AlertDialogPrimitive.Content
+          {...(!description && { "aria-describedby": "confirm-dialog-title" })}
+          data-testid="confirm-dialog"
+          className={cn(
+            "fixed left-[50%] top-[50%] z-50 translate-x-[-50%] translate-y-[-50%]",
+            "w-96 bg-background rounded-xl shadow-[0px_2px_4px_0px_rgba(0,0,0,0.24)] outline outline-1 outline-offset-[-1px] outline-border",
+            "inline-flex flex-col justify-start items-start gap-6 overflow-hidden",
+          )}
+        >
+          {/* Content Section */}
+          <div
+            id="confirm-dialog-title"
+            className="self-stretch px-6 pt-6 flex flex-col justify-start items-start gap-4"
+          >
+            {/* Title */}
+            <AlertDialogPrimitive.Title
+              data-testid="confirm-dialog-title"
+              className="self-stretch justify-start text-foreground text-xl font-semibold font-sans leading-7"
+            >
+              {title}
+            </AlertDialogPrimitive.Title>
+
+            {/* Description */}
+            {description && (
+              <AlertDialogPrimitive.Description
+                data-testid="confirm-dialog-description"
+                className="self-stretch justify-start text-foreground text-base font-normal font-sans leading-snug"
+              >
+                {description}
+              </AlertDialogPrimitive.Description>
+            )}
+
+            {/* Custom Children (e.g., dropdowns, additional fields) */}
+            {children && (
+              <div data-testid="confirm-dialog-children">{children}</div>
+            )}
+
+            {/* Danger Alert */}
+            {dangerAlert && (
+              <div
+                data-testid="confirm-dialog-danger-alert"
+                className="self-stretch p-4 bg-red-50 dark:bg-red-950 rounded outline outline-1 outline-offset-[-1px] outline-red-900 dark:outline-red-700 inline-flex justify-start items-start gap-2.5 overflow-hidden"
+              >
+                <AlertCircle className="w-4 h-4 text-red-900 dark:text-red-400 flex-shrink-0 mt-0.5" />
+                <div className="flex-1 justify-start text-red-900 dark:text-red-400 text-base font-normal font-sans leading-snug">
+                  {dangerAlert.message}
+                </div>
+              </div>
+            )}
+          </div>
+
+          {/* Footer with Buttons */}
+          <div className="self-stretch py-4 bg-neutral-100 dark:bg-neutral-800 inline-flex justify-between items-center">
+            <div className="w-96 px-6 flex justify-between items-center">
+              {/* Cancel Button */}
+              <button
+                data-testid="confirm-dialog-cancel"
+                onClick={onCancel}
+                type="button"
+                disabled={isLoading}
+                className="px-4 py-2 bg-background rounded-md outline outline-1 outline-offset-[-1px] outline-neutral-700 dark:outline-neutral-500 flex justify-center items-center gap-2.5 hover:bg-neutral-50 dark:hover:bg-neutral-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:bg-background dark:disabled:hover:bg-background"
+              >
+                <span className="text-foreground text-sm font-medium leading-normal">
+                  {cancelText}
+                </span>
+              </button>
+
+              {/* Confirm Button */}
+              <button
+                data-testid="confirm-dialog-confirm"
+                onClick={onConfirm}
+                type="button"
+                disabled={isLoading}
+                className="px-4 py-2 bg-primary-mid rounded-md flex justify-center items-center gap-2.5 hover:opacity-90 transition-opacity disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:opacity-50"
+              >
+                {isLoading && (
+                  <Loader2 className="w-4 h-4 text-primary-text animate-spin" />
+                )}
+                <span className="text-primary-text text-sm font-medium leading-normal">
+                  {isLoading && loadingText ? loadingText : confirmText}
+                </span>
+              </button>
+            </div>
+          </div>
+        </AlertDialogPrimitive.Content>
+      </AlertDialogPrimitive.Portal>
+    </AlertDialogPrimitive.Root>
+  );
+}


### PR DESCRIPTION
This PR adds a confirmation dialog component based on the high-fidelity designs, stories and unit tests.

### Unit Tests
<img width="1703" height="1005" alt="Screenshot 2025-10-28 at 9 37 09 am" src="https://github.com/user-attachments/assets/8fe11b9a-317a-4b84-bda9-05ac16a17267" />


### Documentation
<img width="1811" height="1047" alt="Screenshot 2025-10-28 at 9 38 44 am" src="https://github.com/user-attachments/assets/1f8d4e13-5f01-4f47-8851-e505ccd2829a" />

### Light Mode
<img width="1811" height="1047" alt="Screenshot 2025-10-28 at 9 39 04 am" src="https://github.com/user-attachments/assets/efa63aa7-183b-4438-bb72-4af4f3d5b1f9" />

<img width="1811" height="1047" alt="Screenshot 2025-10-28 at 9 59 14 am" src="https://github.com/user-attachments/assets/15d5a170-3b21-4d77-9623-4474beb81a14" />

<img width="1811" height="1047" alt="Screenshot 2025-10-28 at 9 40 54 am" src="https://github.com/user-attachments/assets/fa4bb0ba-53d9-4be3-bcc9-a8e2dde54046" />

### Dark Mode
<img width="1811" height="1047" alt="Screenshot 2025-10-28 at 9 39 09 am" src="https://github.com/user-attachments/assets/2cbb0c28-f541-4776-991e-15631256d043" />
<img width="1811" height="1047" alt="Screenshot 2025-10-28 at 9 39 19 am" src="https://github.com/user-attachments/assets/c67fc684-e11a-4379-975b-b2d92edcb7bd" />



