### PR TITLE
feat: add collection grid

### DIFF
--- a/spa/src/components/collection/collections-grid/CollectionsGrid.stories.tsx
+++ b/spa/src/components/collection/collections-grid/CollectionsGrid.stories.tsx
@@ -1,0 +1,113 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { CollectionsGrid } from "./CollectionsGrid";
+
+const meta: Meta<typeof CollectionsGrid> = {
+  title: "Components/Collection/CollectionsGrid",
+  component: CollectionsGrid,
+  parameters: {
+    layout: "padded",
+    design: {
+      type: "figma",
+      url: "https://www.figma.com/design/SQOopW8mFNB8TLQSZvOySp/RBTP-UI?node-id=9-2514&m=dev",
+    },
+  },
+  tags: ["autodocs"],
+  argTypes: {
+    collections: {
+      description: "Array of collection objects to display in the grid",
+      control: { type: "object" },
+    },
+    loading: {
+      description: "Whether to show loading skeleton state",
+      control: { type: "boolean" },
+      table: {
+        defaultValue: { summary: "false" },
+      },
+    },
+    onCollectionClick: {
+      description: "Callback when a collection is clicked",
+      action: "collection clicked",
+    },
+    onCollectionSettings: {
+      description: "Callback when collection settings button is clicked",
+      action: "settings clicked",
+    },
+    onCreateCollection: {
+      description: "Callback when create collection card is clicked",
+      action: "create collection clicked",
+    },
+    showCreateCollection: {
+      description: "Whether to show the create collection card",
+      control: { type: "boolean" },
+      table: {
+        defaultValue: { summary: "true" },
+      },
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof CollectionsGrid>;
+
+const mockCollections = [
+  { id: "collection-a", name: "Collection A", fileCount: 122 },
+  { id: "collection-b", name: "Collection B", fileCount: 45 },
+  { id: "collection-c", name: "Collection C", fileCount: 78 },
+  { id: "collection-d", name: "Collection D", fileCount: 234 },
+];
+
+export const Default: Story = {
+  args: {
+    collections: mockCollections.slice(0, 3),
+    onCollectionClick: (id) => console.log("Collection clicked:", id),
+    onCollectionSettings: (id) => console.log("Settings clicked:", id),
+    onCreateCollection: () => console.log("Create collection clicked"),
+  },
+};
+
+export const Loading: Story = {
+  args: {
+    collections: mockCollections,
+    loading: true,
+    onCollectionClick: (id) => console.log("Collection clicked:", id),
+    onCollectionSettings: (id) => console.log("Settings clicked:", id),
+    onCreateCollection: () => console.log("Create collection clicked"),
+  },
+};
+
+export const Empty: Story = {
+  args: {
+    collections: [],
+    onCollectionClick: (id) => console.log("Collection clicked:", id),
+    onCollectionSettings: (id) => console.log("Settings clicked:", id),
+    onCreateCollection: () => console.log("Create collection clicked"),
+  },
+};
+
+export const WithoutCreateButton: Story = {
+  args: {
+    collections: mockCollections.slice(0, 3),
+    onCollectionClick: (id) => console.log("Collection clicked:", id),
+    onCollectionSettings: (id) => console.log("Settings clicked:", id),
+    onCreateCollection: () => console.log("Create collection clicked"),
+    showCreateCollection: false,
+  },
+};
+
+export const SingleCollection: Story = {
+  args: {
+    collections: [mockCollections[0]],
+    onCollectionClick: (id) => console.log("Collection clicked:", id),
+    onCollectionSettings: (id) => console.log("Settings clicked:", id),
+    onCreateCollection: () => console.log("Create collection clicked"),
+  },
+};
+
+export const WithManyCollections: Story = {
+  args: {
+    collections: mockCollections,
+    onCollectionClick: (id) => console.log("Collection clicked:", id),
+    onCollectionSettings: (id) => console.log("Settings clicked:", id),
+    onCreateCollection: () => console.log("Create collection clicked"),
+  },
+};

--- a/spa/src/components/collection/collections-grid/CollectionsGrid.test.tsx
+++ b/spa/src/components/collection/collections-grid/CollectionsGrid.test.tsx
@@ -1,0 +1,84 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { CollectionsGrid } from "./CollectionsGrid";
+
+describe("CollectionsGrid", () => {
+  const mockCollections = [
+    { id: "collection-a", name: "Collection A", fileCount: 122 },
+    { id: "collection-b", name: "Collection B", fileCount: 45 },
+    { id: "collection-c", name: "Collection C", fileCount: 78 },
+  ];
+
+  const defaultProps = {
+    collections: mockCollections,
+    onCollectionClick: vi.fn(),
+    onCollectionSettings: vi.fn(),
+    onCreateCollection: vi.fn(),
+  };
+
+  it("renders all collections", () => {
+    render(<CollectionsGrid {...defaultProps} />);
+
+    expect(screen.getByTestId("collections-grid")).toBeInTheDocument();
+    expect(
+      screen.getByTestId("collection-card-collection-a"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId("collection-card-collection-b"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId("collection-card-collection-c"),
+    ).toBeInTheDocument();
+  });
+
+  it("renders create collection card", () => {
+    render(<CollectionsGrid {...defaultProps} />);
+
+    expect(screen.getByTestId("create-collection-card")).toBeInTheDocument();
+  });
+
+  it("calls onCollectionClick when collection is clicked", async () => {
+    const user = userEvent.setup();
+    render(<CollectionsGrid {...defaultProps} />);
+
+    const viewButton = screen.getByTestId("view-button-collection-a");
+    await user.click(viewButton);
+
+    expect(defaultProps.onCollectionClick).toHaveBeenCalledWith("collection-a");
+  });
+
+  it("calls onCreateCollection when create card is clicked", async () => {
+    const user = userEvent.setup();
+    render(<CollectionsGrid {...defaultProps} />);
+
+    const createButton = screen.getByTestId("create-collection-card");
+    await user.click(createButton);
+
+    expect(defaultProps.onCreateCollection).toHaveBeenCalled();
+  });
+
+  it("renders loading skeletons when loading", () => {
+    render(<CollectionsGrid {...defaultProps} loading={true} />);
+
+    expect(screen.getByTestId("collections-grid-loading")).toBeInTheDocument();
+    expect(screen.getByTestId("collection-skeleton-1")).toBeInTheDocument();
+    expect(screen.getByTestId("collection-skeleton-2")).toBeInTheDocument();
+    expect(screen.getByTestId("collection-skeleton-3")).toBeInTheDocument();
+    expect(screen.getByTestId("collection-skeleton-4")).toBeInTheDocument();
+    expect(screen.getByTestId("collection-skeleton-5")).toBeInTheDocument();
+
+    // Collections should not be visible when loading
+    expect(
+      screen.queryByTestId("collection-card-collection-a"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("hides create collection card when showCreateCollection is false", () => {
+    render(<CollectionsGrid {...defaultProps} showCreateCollection={false} />);
+
+    expect(
+      screen.queryByTestId("create-collection-card"),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/spa/src/components/collection/collections-grid/CollectionsGrid.tsx
+++ b/spa/src/components/collection/collections-grid/CollectionsGrid.tsx
@@ -1,0 +1,59 @@
+import { CollectionCard } from "@/components/collection/collection-card/CollectionCard";
+import { CreateCollectionCard } from "@/components/collection/create-collection-card/CreateCollectionCard";
+import { Skeleton } from "@/components/ui/skeleton";
+import type { Collection } from "@/types";
+
+export interface CollectionsGridProps {
+  collections: Collection[];
+  loading?: boolean;
+  onCollectionClick: (collectionId: string) => void;
+  onCollectionSettings: (collectionId: string) => void;
+  onCreateCollection: () => void;
+  showCreateCollection?: boolean;
+}
+
+export function CollectionsGrid({
+  collections,
+  loading = false,
+  onCollectionClick,
+  onCollectionSettings,
+  onCreateCollection,
+  showCreateCollection = true,
+}: CollectionsGridProps) {
+  if (loading) {
+    return (
+      <div
+        className="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-3 gap-4 md:gap-8"
+        data-testid="collections-grid-loading"
+      >
+        {[1, 2, 3, 4, 5].map((i) => (
+          <Skeleton
+            key={i}
+            className="h-[140px] xl:h-[132px] rounded-[4px]"
+            data-testid={`collection-skeleton-${i}`}
+          />
+        ))}
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-3 gap-4 md:gap-8"
+      data-testid="collections-grid"
+    >
+      {collections.map((collection) => (
+        <CollectionCard
+          key={collection.id}
+          name={collection.name}
+          fileCount={collection.fileCount || 0}
+          onViewClick={() => onCollectionClick(collection.id)}
+          onSettingsClick={() => onCollectionSettings(collection.id)}
+        />
+      ))}
+      {showCreateCollection && (
+        <CreateCollectionCard onClick={onCreateCollection} />
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
This PR adds a collection grid component based on the high-fidelity designs, stories and unit tests.

### Unit Tests
<img width="1553" height="1005" alt="Screenshot 2025-10-29 at 1 38 04 pm" src="https://github.com/user-attachments/assets/576ffc6a-7c1c-481a-9cb6-b4e2c96bee59" />

### Documentation
<img width="1835" height="1047" alt="Screenshot 2025-10-29 at 1 29 25 pm" src="https://github.com/user-attachments/assets/200c47b8-ec1b-4e2b-bfdd-2feceff595a0" />

### Light Mode


<img width="1835" height="1047" alt="Screenshot 2025-10-29 at 1 29 44 pm" src="https://github.com/user-attachments/assets/4d9f1103-3421-43e1-a728-446147a64c08" />
<img width="1835" height="1047" alt="Screenshot 2025-10-29 at 1 29 51 pm" src="https://github.com/user-attachments/assets/9b82919d-5168-41a4-8d3f-ee7eb6e4544f" />
<img width="1835" height="1047" alt="Screenshot 2025-10-29 at 1 29 55 pm" src="https://github.com/user-attachments/assets/8039939b-4981-4a94-94c1-a380162ce664" />






