### PR TITLE
fix: make sidebar responsive

### DIFF
--- a/spa/src/components/sidebar/Sidebar.stories.tsx
+++ b/spa/src/components/sidebar/Sidebar.stories.tsx
@@ -7,6 +7,13 @@ import { useState } from "react";
 const meta = {
   title: "Components/Sidebar/Sidebar",
   component: Sidebar,
+  decorators: [
+    (Story) => (
+      <div style={{ height: "100vh" }}>
+        <Story />
+      </div>
+    ),
+  ],
   parameters: {
     layout: "fullscreen",
     design: {
@@ -49,6 +56,18 @@ const meta = {
       action: "logout clicked",
       description: "Callback when logout is clicked",
     },
+    isLoading: {
+      control: "boolean",
+      description: "Whether the sidebar is in loading state",
+    },
+    hideHeader: {
+      control: "boolean",
+      description: "Whether to hide the sidebar header",
+    },
+    className: {
+      control: "text",
+      description: "Additional CSS classes",
+    },
   },
 } satisfies Meta<typeof Sidebar>;
 
@@ -67,6 +86,7 @@ export const AdminUser: Story = {
       name: "Cindy Reardon",
       email: "c.reardon@emailadress.com",
       roles: [UserRole.Admin],
+      collections: {},
     },
     onCollectionSelect: () => console.log("Collection selected"),
     onHomeClick: () => console.log("Home clicked"),
@@ -86,7 +106,8 @@ export const RegularUser: Story = {
     user: {
       name: "John Doe",
       email: "john.doe@example.com",
-      roles: [UserRole.User],
+      roles: [UserRole.ProjectParticipant],
+      collections: {},
     },
     onCollectionSelect: () => console.log("Collection selected"),
     onHomeClick: () => console.log("Home clicked"),
@@ -117,6 +138,7 @@ export const WithAvatar: Story = {
       email: "c.reardon@emailadress.com",
       roles: [UserRole.Admin],
       avatarUrl: faker.image.avatar(),
+      collections: {},
     },
   },
 };
@@ -128,6 +150,7 @@ export const EmptyCollections: Story = {
       name: "Cindy Reardon",
       email: "c.reardon@emailadress.com",
       roles: [UserRole.Admin],
+      collections: {},
     },
     onCollectionSelect: () => console.log("Collection selected"),
     onHomeClick: () => console.log("Home clicked"),
@@ -143,6 +166,7 @@ export const ManyCollections: Story = {
       name: "Cindy Reardon",
       email: "c.reardon@emailadress.com",
       roles: [UserRole.Admin],
+      collections: {},
     },
     onCollectionSelect: () => console.log("Collection selected"),
     onHomeClick: () => console.log("Home clicked"),
@@ -192,6 +216,7 @@ export const ManyCollections: Story = {
             name: "Cindy Reardon",
             email: "c.reardon@emailadress.com",
             roles: [UserRole.Admin],
+            collections: {},
           }}
         />
       );
@@ -215,6 +240,7 @@ export const LongUserInfo: Story = {
       name: "Christina Marie Reardon-Smith",
       email: "christina.marie.reardon-smith@verylongemailaddress.com",
       roles: [UserRole.Admin],
+      collections: {},
     },
   },
 };
@@ -229,6 +255,37 @@ export const Loading: Story = {
       description: {
         story:
           "Loading state with skeleton placeholders. This is shown while user data or collections are being fetched.",
+      },
+    },
+  },
+};
+
+export const HiddenHeader: Story = {
+  args: {
+    ...AdminUser.args,
+    hideHeader: true,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Sidebar with header hidden. Useful for embedded or mobile views where the header is shown elsewhere.",
+      },
+    },
+  },
+};
+
+export const LoadingWithHiddenHeader: Story = {
+  args: {
+    ...AdminUser.args,
+    isLoading: true,
+    hideHeader: true,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Loading state with header hidden. Shows skeleton without the header section.",
       },
     },
   },

--- a/spa/src/components/sidebar/Sidebar.test.tsx
+++ b/spa/src/components/sidebar/Sidebar.test.tsx
@@ -14,12 +14,14 @@ const mockAdminUser: User = {
   name: "Cindy Reardon",
   email: "c.reardon@emailadress.com",
   roles: [UserRole.Admin],
+  collections: {},
 };
 
 const mockRegularUser: User = {
   name: "John Doe",
   email: "john.doe@example.com",
-  roles: [UserRole.User],
+  roles: [UserRole.ProjectParticipant],
+  collections: {},
 };
 
 const defaultProps = {
@@ -38,11 +40,25 @@ describe("Sidebar", () => {
     expect(screen.getByTestId("sidebar")).toBeInTheDocument();
   });
 
-  it("renders the header", () => {
+  it("renders the header by default", () => {
     render(<Sidebar {...defaultProps} />);
 
     expect(screen.getByTestId("sidebar-header")).toBeInTheDocument();
     expect(screen.getByText("STUF")).toBeInTheDocument();
+  });
+
+  it("renders the header when hideHeader is false", () => {
+    render(<Sidebar {...defaultProps} hideHeader={false} />);
+
+    expect(screen.getByTestId("sidebar-header")).toBeInTheDocument();
+    expect(screen.getByText("STUF")).toBeInTheDocument();
+  });
+
+  it("hides the header when hideHeader is true", () => {
+    render(<Sidebar {...defaultProps} hideHeader={true} />);
+
+    expect(screen.queryByTestId("sidebar-header")).not.toBeInTheDocument();
+    expect(screen.queryByText("STUF")).not.toBeInTheDocument();
   });
 
   it("renders the collection navigation", () => {
@@ -190,13 +206,6 @@ describe("Sidebar", () => {
     expect(menuTrigger).toHaveClass("cursor-pointer");
   });
 
-  it("menu trigger icon is visible", () => {
-    const { container } = render(<Sidebar {...defaultProps} />);
-
-    const menuIcon = container.querySelector('img[src="/icons/more_vert.svg"]');
-    expect(menuIcon).toBeInTheDocument();
-  });
-
   it("shows Configuration nav item for admin users", () => {
     render(<Sidebar {...defaultProps} user={mockAdminUser} />);
 
@@ -217,7 +226,8 @@ describe("Sidebar", () => {
     const limitedUser: User = {
       name: "Limited User",
       email: "limited@example.com",
-      roles: [UserRole.Limited],
+      roles: [UserRole.ProjectParticipant],
+      collections: {},
     };
 
     render(<Sidebar {...defaultProps} user={limitedUser} />);
@@ -226,5 +236,25 @@ describe("Sidebar", () => {
       screen.queryByTestId("nav-item-configuration"),
     ).not.toBeInTheDocument();
     expect(screen.queryByText("Configuration")).not.toBeInTheDocument();
+  });
+
+  it("renders skeleton when isLoading is true", () => {
+    render(<Sidebar {...defaultProps} isLoading={true} />);
+
+    expect(screen.getByTestId("sidebar-skeleton")).toBeInTheDocument();
+  });
+
+  it("skeleton shows header by default when loading", () => {
+    render(<Sidebar {...defaultProps} isLoading={true} />);
+
+    expect(screen.getByTestId("sidebar-skeleton")).toBeInTheDocument();
+    expect(screen.getByTestId("sidebar-header")).toBeInTheDocument();
+  });
+
+  it("skeleton hides header when hideHeader is true and loading", () => {
+    render(<Sidebar {...defaultProps} isLoading={true} hideHeader={true} />);
+
+    expect(screen.getByTestId("sidebar-skeleton")).toBeInTheDocument();
+    expect(screen.queryByTestId("sidebar-header")).not.toBeInTheDocument();
   });
 });

--- a/spa/src/components/sidebar/Sidebar.tsx
+++ b/spa/src/components/sidebar/Sidebar.tsx
@@ -19,6 +19,7 @@ interface SidebarProps {
   user: User;
   onLogout: () => void;
   isLoading?: boolean;
+  hideHeader?: boolean;
   className?: string;
 }
 
@@ -32,22 +33,23 @@ export function Sidebar({
   user,
   onLogout,
   isLoading = false,
+  hideHeader = false,
   className,
 }: SidebarProps) {
   if (isLoading) {
-    return <SidebarSkeleton className={className} />;
+    return <SidebarSkeleton hideHeader={hideHeader} className={className} />;
   }
 
   return (
     <aside
       className={cn(
-        "w-72 h-screen bg-sidebar px-6 py-7 flex flex-col justify-between items-start overflow-hidden",
+        "w-72 h-full bg-sidebar px-6 py-7 flex flex-col justify-between items-start overflow-hidden",
         className,
       )}
       data-testid="sidebar"
     >
       <div className="self-stretch flex flex-col justify-start items-start gap-6">
-        <SidebarHeader />
+        {!hideHeader && <SidebarHeader />}
 
         <div className="self-stretch flex flex-col justify-start items-start gap-2">
           <CollectionNav

--- a/spa/src/components/sidebar/SidebarSkeleton.stories.tsx
+++ b/spa/src/components/sidebar/SidebarSkeleton.stories.tsx
@@ -1,0 +1,61 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { SidebarSkeleton } from "./SidebarSkeleton";
+
+const meta = {
+  title: "Components/Sidebar/SidebarSkeleton",
+  component: SidebarSkeleton,
+  decorators: [
+    (Story) => (
+      <div style={{ height: "100vh" }}>
+        <Story />
+      </div>
+    ),
+  ],
+  parameters: {
+    layout: "fullscreen",
+    design: {
+      type: "figma",
+      url: "https://www.figma.com/design/SQOopW8mFNB8TLQSZvOySp/RBTP-UI?node-id=365-4002&m=dev",
+    },
+  },
+  tags: ["autodocs"],
+  argTypes: {
+    hideHeader: {
+      control: "boolean",
+      description: "Whether to hide the sidebar header",
+    },
+    className: {
+      control: "text",
+      description: "Additional CSS classes",
+    },
+  },
+} satisfies Meta<typeof SidebarSkeleton>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {},
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Default skeleton state with header visible. Shows loading placeholders for all sidebar elements.",
+      },
+    },
+  },
+};
+
+export const HiddenHeader: Story = {
+  args: {
+    hideHeader: true,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Skeleton with header hidden. Useful for embedded or mobile views where the header is shown elsewhere.",
+      },
+    },
+  },
+};

--- a/spa/src/components/sidebar/SidebarSkeleton.test.tsx
+++ b/spa/src/components/sidebar/SidebarSkeleton.test.tsx
@@ -1,0 +1,60 @@
+import { render, screen } from "@testing-library/react";
+import { SidebarSkeleton } from "./SidebarSkeleton";
+
+describe("SidebarSkeleton", () => {
+  it("renders the skeleton", () => {
+    render(<SidebarSkeleton />);
+
+    expect(screen.getByTestId("sidebar-skeleton")).toBeInTheDocument();
+  });
+
+  it("shows header by default", () => {
+    render(<SidebarSkeleton />);
+
+    expect(screen.getByTestId("sidebar-skeleton")).toBeInTheDocument();
+    expect(screen.getByTestId("sidebar-header")).toBeInTheDocument();
+  });
+
+  it("shows header when hideHeader is false", () => {
+    render(<SidebarSkeleton hideHeader={false} />);
+
+    expect(screen.getByTestId("sidebar-skeleton")).toBeInTheDocument();
+    expect(screen.getByTestId("sidebar-header")).toBeInTheDocument();
+  });
+
+  it("hides header when hideHeader is true", () => {
+    render(<SidebarSkeleton hideHeader={true} />);
+
+    expect(screen.getByTestId("sidebar-skeleton")).toBeInTheDocument();
+    expect(screen.queryByTestId("sidebar-header")).not.toBeInTheDocument();
+  });
+
+  it("applies custom className", () => {
+    render(<SidebarSkeleton className="custom-class" />);
+
+    const skeleton = screen.getByTestId("sidebar-skeleton");
+    expect(skeleton).toHaveClass("custom-class");
+  });
+
+  it("renders skeleton placeholders for navigation items", () => {
+    render(<SidebarSkeleton />);
+
+    const skeleton = screen.getByTestId("sidebar-skeleton");
+    expect(skeleton).toBeInTheDocument();
+
+    // Should have multiple skeleton elements (using Skeleton component from ui)
+    const skeletons = skeleton.querySelectorAll('[class*="animate-pulse"]');
+    expect(skeletons.length).toBeGreaterThan(0);
+  });
+
+  it("renders skeleton placeholder for profile section", () => {
+    render(<SidebarSkeleton />);
+
+    const skeleton = screen.getByTestId("sidebar-skeleton");
+    expect(skeleton).toBeInTheDocument();
+
+    // Should have skeleton elements in the footer area
+    const skeletons = skeleton.querySelectorAll('[class*="animate-pulse"]');
+    expect(skeletons.length).toBeGreaterThan(5); // Multiple skeleton items
+  });
+});

--- a/spa/src/components/sidebar/SidebarSkeleton.tsx
+++ b/spa/src/components/sidebar/SidebarSkeleton.tsx
@@ -3,10 +3,14 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { SidebarHeader } from "./header/SidebarHeader";
 
 interface SidebarSkeletonProps {
+  hideHeader?: boolean;
   className?: string;
 }
 
-export function SidebarSkeleton({ className }: SidebarSkeletonProps) {
+export function SidebarSkeleton({
+  hideHeader = false,
+  className,
+}: SidebarSkeletonProps) {
   // Primary color for both light and dark modes
   const skeletonClass = "bg-primary/30 dark:bg-primary/20";
 
@@ -20,8 +24,8 @@ export function SidebarSkeleton({ className }: SidebarSkeletonProps) {
     >
       {/* Top section */}
       <div className="self-stretch flex flex-col justify-start items-start gap-6 w-full">
-        {/* Real header - always visible */}
-        <SidebarHeader />
+        {/* Real header - conditionally visible */}
+        {!hideHeader && <SidebarHeader />}
 
         {/* Navigation skeleton */}
         <div className="self-stretch flex flex-col justify-start items-start gap-2 w-full">

--- a/spa/src/components/sidebar/footer/SidebarFooter.stories.tsx
+++ b/spa/src/components/sidebar/footer/SidebarFooter.stories.tsx
@@ -44,7 +44,8 @@ export const Default: Story = {
     user: {
       name: "Cindy Reardon",
       email: "c.reardon@emailadress.com",
-      roles: [UserRole.User],
+      roles: [UserRole.ProjectParticipant],
+      collections: {},
     },
     onLogout: () => console.log("Logout clicked"),
   },
@@ -55,8 +56,9 @@ export const WithAvatar: Story = {
     user: {
       name: "Cindy Reardon",
       email: "c.reardon@emailadress.com",
-      roles: [UserRole.User],
+      roles: [UserRole.ProjectParticipant],
       avatarUrl: faker.image.avatar(),
+      collections: {},
     },
     onLogout: () => console.log("Logout clicked"),
   },
@@ -67,7 +69,8 @@ export const LongUserInfo: Story = {
     user: {
       name: "Christina Marie Reardon-Smith",
       email: "christina.marie.reardon-smith@verylongemailaddress.com",
-      roles: [UserRole.User],
+      roles: [UserRole.ProjectParticipant],
+      collections: {},
     },
     onLogout: () => console.log("Logout clicked"),
   },

--- a/spa/src/components/sidebar/footer/SidebarFooter.test.tsx
+++ b/spa/src/components/sidebar/footer/SidebarFooter.test.tsx
@@ -7,7 +7,8 @@ import { UserRole, type User } from "@/types";
 const mockUser: User = {
   name: "Cindy Reardon",
   email: "c.reardon@emailadress.com",
-  roles: [UserRole.User],
+  roles: [UserRole.ProjectParticipant],
+  collections: {},
 };
 
 describe("SidebarFooter", () => {

--- a/spa/src/components/sidebar/mobile/MobileSidebar.stories.tsx
+++ b/spa/src/components/sidebar/mobile/MobileSidebar.stories.tsx
@@ -52,6 +52,14 @@ const meta = {
       action: "logout clicked",
       description: "Callback when logout is clicked",
     },
+    isLoading: {
+      control: "boolean",
+      description: "Whether the sidebar is in loading state",
+    },
+    className: {
+      control: "text",
+      description: "Additional CSS classes for the mobile navbar",
+    },
   },
 } satisfies Meta<typeof MobileSidebar>;
 
@@ -70,6 +78,7 @@ export const AdminUser: Story = {
       name: "Cindy Reardon",
       email: "c.reardon@emailadress.com",
       roles: [UserRole.Admin],
+      collections: {},
     },
     onCollectionSelect: () => console.log("Collection selected"),
     onHomeClick: () => console.log("Home clicked"),
@@ -89,7 +98,8 @@ export const RegularUser: Story = {
     user: {
       name: "John Doe",
       email: "john.doe@example.com",
-      roles: [UserRole.User],
+      roles: [UserRole.ProjectParticipant],
+      collections: {},
     },
     onCollectionSelect: () => console.log("Collection selected"),
     onHomeClick: () => console.log("Home clicked"),
@@ -113,6 +123,7 @@ export const WithAvatar: Story = {
       email: "c.reardon@emailadress.com",
       roles: [UserRole.Admin],
       avatarUrl: faker.image.avatar(),
+      collections: {},
     },
   },
 };
@@ -124,6 +135,7 @@ export const ManyCollections: Story = {
       name: "Cindy Reardon",
       email: "c.reardon@emailadress.com",
       roles: [UserRole.Admin],
+      collections: {},
     },
     onCollectionSelect: () => console.log("Collection selected"),
     onHomeClick: () => console.log("Home clicked"),
@@ -173,6 +185,7 @@ export const ManyCollections: Story = {
             name: "Cindy Reardon",
             email: "c.reardon@emailadress.com",
             roles: [UserRole.Admin],
+            collections: {},
           }}
         />
       );

--- a/spa/src/components/sidebar/mobile/MobileSidebar.tsx
+++ b/spa/src/components/sidebar/mobile/MobileSidebar.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { cn } from "@/lib/utils";
 import { Sidebar } from "../Sidebar";
 import type { Collection, User } from "@/types";
@@ -19,6 +19,19 @@ interface MobileSidebarProps {
 export function MobileSidebar(props: MobileSidebarProps) {
   const [isOpen, setIsOpen] = useState(false);
 
+  // Close sidebar when resizing to desktop size
+  useEffect(() => {
+    const handleResize = () => {
+      // lg breakpoint is 1024px
+      if (window.innerWidth >= 1024) {
+        setIsOpen(false);
+      }
+    };
+
+    window.addEventListener("resize", handleResize);
+    return () => window.removeEventListener("resize", handleResize);
+  }, []);
+
   const handleCollectionSelect = (collectionId: string) => {
     props.onCollectionSelect(collectionId);
     setIsOpen(false);
@@ -36,37 +49,53 @@ export function MobileSidebar(props: MobileSidebarProps) {
 
   return (
     <>
-      {/* Hamburger button */}
-      <button
-        onClick={() => setIsOpen(!isOpen)}
+      {/* Mobile Navbar */}
+      <nav
         className={cn(
-          "fixed top-4 right-4 z-50 p-2 rounded-md bg-background border border-border hover:bg-accent transition-colors",
+          "fixed top-0 left-0 right-0 z-50 bg-background border-b border-border",
           props.className,
         )}
-        aria-label={isOpen ? "Close menu" : "Open menu"}
-        data-testid="mobile-sidebar-toggle"
+        data-testid="mobile-navbar"
       >
-        <div className="w-6 h-6 flex flex-col justify-center items-center gap-1.5">
-          <span
-            className={cn(
-              "w-full h-0.5 bg-foreground transition-transform duration-200 origin-center",
-              isOpen && "rotate-45 translate-y-2",
-            )}
-          />
-          <span
-            className={cn(
-              "w-full h-0.5 bg-foreground transition-opacity duration-200",
-              isOpen && "opacity-0",
-            )}
-          />
-          <span
-            className={cn(
-              "w-full h-0.5 bg-foreground transition-transform duration-200 origin-center",
-              isOpen && "-rotate-45 -translate-y-2",
-            )}
-          />
+        <div className="flex justify-between items-center px-4 py-4">
+          {/* STUF Logo */}
+          <div
+            className="text-foreground text-3xl font-extrabold font-sans leading-10"
+            data-testid="mobile-navbar-logo"
+          >
+            STUF
+          </div>
+
+          {/* Hamburger button */}
+          <button
+            onClick={() => setIsOpen(!isOpen)}
+            className="p-2 rounded-md hover:bg-accent transition-colors"
+            aria-label={isOpen ? "Close menu" : "Open menu"}
+            data-testid="mobile-sidebar-toggle"
+          >
+            <div className="w-6 h-6 flex flex-col justify-center items-center gap-1.5">
+              <span
+                className={cn(
+                  "w-full h-0.5 bg-foreground transition-transform duration-200 origin-center",
+                  isOpen && "rotate-45 translate-y-2",
+                )}
+              />
+              <span
+                className={cn(
+                  "w-full h-0.5 bg-foreground transition-opacity duration-200",
+                  isOpen && "opacity-0",
+                )}
+              />
+              <span
+                className={cn(
+                  "w-full h-0.5 bg-foreground transition-transform duration-200 origin-center",
+                  isOpen && "-rotate-45 -translate-y-2",
+                )}
+              />
+            </div>
+          </button>
         </div>
-      </button>
+      </nav>
 
       {/* Overlay */}
       {isOpen && (
@@ -80,13 +109,14 @@ export function MobileSidebar(props: MobileSidebarProps) {
       {/* Sidebar - shows skeleton inside when loading */}
       <div
         className={cn(
-          "fixed top-0 left-0 z-40 transition-transform duration-300 ease-in-out",
+          "fixed top-16 left-0 z-40 transition-transform duration-300 ease-in-out h-[calc(100vh-4rem)]",
           isOpen ? "translate-x-0" : "-translate-x-full",
         )}
         data-testid="mobile-sidebar"
       >
         <Sidebar
           {...props}
+          hideHeader={true}
           onCollectionSelect={handleCollectionSelect}
           onHomeClick={handleHomeClick}
           onConfigClick={handleConfigClick}

--- a/spa/src/components/sidebar/profile/SidebarProfile.stories.tsx
+++ b/spa/src/components/sidebar/profile/SidebarProfile.stories.tsx
@@ -1,7 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { faker } from "@faker-js/faker";
 import { SidebarProfile } from "./SidebarProfile";
-import { UserRole } from "@/types";
 
 const meta = {
   title: "Components/Sidebar/SidebarProfile",
@@ -40,8 +39,9 @@ export const Default: Story = {
     user: {
       name: faker.person.fullName(),
       email: faker.internet.email(),
-      roles: [UserRole.User],
+      roles: [],
       avatarUrl: faker.image.avatar(),
+      collections: {},
     },
   },
 };
@@ -51,7 +51,8 @@ export const WithPlaceholder: Story = {
     user: {
       name: "Cindy Reardon",
       email: "c.reardon@emailadress.com",
-      roles: [UserRole.User],
+      roles: [],
+      collections: {},
     },
   },
 };
@@ -61,8 +62,9 @@ export const TruncatedName: Story = {
     user: {
       name: "Dr. Christopher Alexander Montgomery Wellington III",
       email: "c.montgomery@example.com",
-      roles: [UserRole.User],
+      roles: [],
       avatarUrl: faker.image.avatar(),
+      collections: {},
     },
   },
 };
@@ -73,8 +75,9 @@ export const TruncatedEmail: Story = {
       name: "Jane Doe",
       email:
         "jane.doe.with.a.very.long.email.address@corporate-company-domain.com",
-      roles: [UserRole.User],
+      roles: [],
       avatarUrl: faker.image.avatar(),
+      collections: {},
     },
   },
 };
@@ -84,8 +87,9 @@ export const BothTruncated: Story = {
     user: {
       name: "Dr. Alexander Christopher Montgomery Wellington",
       email: "alexander.christopher.montgomery@very-long-corporate-domain.com",
-      roles: [UserRole.User],
+      roles: [],
       avatarUrl: faker.image.avatar(),
+      collections: {},
     },
   },
 };

--- a/spa/src/components/sidebar/profile/SidebarProfile.test.tsx
+++ b/spa/src/components/sidebar/profile/SidebarProfile.test.tsx
@@ -1,11 +1,12 @@
 import { render, screen } from "@testing-library/react";
 import { SidebarProfile } from "./SidebarProfile";
-import { UserRole, type User } from "@/types";
+import type { User } from "@/types";
 
 const mockUser: User = {
   name: "John Doe",
   email: "john@example.com",
-  roles: [UserRole.User],
+  roles: [],
+  collections: {},
 };
 
 describe("SidebarProfile", () => {
@@ -34,7 +35,8 @@ describe("SidebarProfile", () => {
         user={{
           name: "Dr. Christopher Alexander Montgomery Wellington III",
           email: "short@example.com",
-          roles: [UserRole.User],
+          roles: [],
+          collections: {},
         }}
       />,
     );
@@ -49,7 +51,8 @@ describe("SidebarProfile", () => {
         user={{
           name: "Jane Doe",
           email: "very.long.email.address@corporate-company-domain.com",
-          roles: [UserRole.User],
+          roles: [],
+          collections: {},
         }}
       />,
     );


### PR DESCRIPTION
This PR updates the sidebar components to improve responsive behaviour across different viewports. It introduces a hideHeader prop for better layout control, adds skeleton states for loading views, and enhances the mobile sidebar to automatically close on resize to desktop width. Storybook stories and tests have been updated accordingly.

<img width="1553" height="1005" alt="Screenshot 2025-10-29 at 2 17 15 pm" src="https://github.com/user-attachments/assets/e06eecd8-80fa-4b47-babd-91384e83c3af" />
<img width="1835" height="1047" alt="Screenshot 2025-10-29 at 2 17 45 pm" src="https://github.com/user-attachments/assets/e4ef837c-ab69-4e6d-851e-55905b4a1ef3" />
<img width="1835" height="1047" alt="Screenshot 2025-10-29 at 2 17 49 pm" src="https://github.com/user-attachments/assets/bd078c05-672c-4b52-b7e2-44390a122f20" />
<img width="1835" height="1047" alt="Screenshot 2025-10-29 at 2 17 56 pm" src="https://github.com/user-attachments/assets/909030cb-ecf0-4d8b-af68-b40b86687802" />
<img width="1835" height="1047" alt="Screenshot 2025-10-29 at 2 18 22 pm" src="https://github.com/user-attachments/assets/a358cd2b-a4a2-4e9f-9b21-a36004bfe852" />
<img width="1835" height="1047" alt="Screenshot 2025-10-29 at 2 18 28 pm" src="https://github.com/user-attachments/assets/41e97732-52fc-4aab-9686-3d2432f0a97c" />
<img width="1835" height="1047" alt="Screenshot 2025-10-29 at 2 18 31 pm" src="https://github.com/user-attachments/assets/8d1005c2-2173-4c6c-a3ef-4aab8ab48540" />
