### PR TITLE
feat: add signin page

### DIFF
--- a/spa/src/pages/sign-in/SignIn.stories.tsx
+++ b/spa/src/pages/sign-in/SignIn.stories.tsx
@@ -1,0 +1,45 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { SignIn } from "./SignIn";
+import { AuthProvider } from "react-oidc-context";
+import { MemoryRouter } from "react-router-dom";
+
+const meta = {
+  title: "Pages/SignIn/SignIn",
+  component: SignIn,
+  parameters: {
+    layout: "fullscreen",
+    design: {
+      type: "figma",
+      url: "https://www.figma.com/design/SQOopW8mFNB8TLQSZvOySp/RBTP-UI?node-id=6-2&m=dev",
+    },
+  },
+  decorators: [
+    (Story) => {
+      const oidcConfig = {
+        authority: "http://localhost:8080/realms/stuf",
+        client_id: "stuf-spa",
+        redirect_uri: window.location.origin,
+        onSigninCallback: () => {
+          window.history.replaceState(
+            {},
+            document.title,
+            window.location.pathname,
+          );
+        },
+      };
+
+      return (
+        <MemoryRouter>
+          <AuthProvider {...oidcConfig}>
+            <Story />
+          </AuthProvider>
+        </MemoryRouter>
+      );
+    },
+  ],
+} satisfies Meta<typeof SignIn>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/spa/src/pages/sign-in/SignIn.test.tsx
+++ b/spa/src/pages/sign-in/SignIn.test.tsx
@@ -1,0 +1,143 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import userEvent from "@testing-library/user-event";
+import { SignIn } from "./SignIn";
+
+const mockSigninRedirect = vi.fn();
+const mockAuthState = {
+  isAuthenticated: false,
+  isLoading: false,
+  signinRedirect: mockSigninRedirect,
+};
+
+vi.mock("react-oidc-context", async () => {
+  const actual = await vi.importActual("react-oidc-context");
+  return {
+    ...actual,
+    useAuth: () => mockAuthState,
+  };
+});
+
+describe("SignIn", () => {
+  beforeEach(() => {
+    mockSigninRedirect.mockClear();
+    mockAuthState.isAuthenticated = false;
+  });
+
+  const TestRouter = ({
+    children,
+    initialEntries,
+  }: {
+    children: React.ReactNode;
+    initialEntries?: any[];
+  }) => (
+    <MemoryRouter
+      initialEntries={initialEntries}
+      future={{
+        v7_startTransition: false,
+        v7_relativeSplatPath: false,
+      }}
+    >
+      {children}
+    </MemoryRouter>
+  );
+
+  const renderWithRouter = () => {
+    return render(
+      <TestRouter>
+        <SignIn />
+      </TestRouter>,
+    );
+  };
+
+  it("renders the sign-in page", () => {
+    renderWithRouter();
+    expect(screen.getByTestId("sign-in")).toBeInTheDocument();
+  });
+
+  it("renders the sign-in title", () => {
+    renderWithRouter();
+    expect(screen.getByTestId("sign-in-title")).toHaveTextContent(
+      "Sign in to STUF",
+    );
+  });
+
+  it("renders the description text", () => {
+    renderWithRouter();
+    expect(screen.getByTestId("sign-in-description")).toHaveTextContent(
+      "STUF is a comprehensive system for secure file uploads developed by Pyx.",
+    );
+  });
+
+  it("renders the Pyx website link", () => {
+    renderWithRouter();
+    const link = screen.getByTestId("sign-in-pyx-link");
+    expect(link).toHaveAttribute("href", "https://pyx.io");
+    expect(link).toHaveTextContent("Pyx Website");
+  });
+
+  it("renders the sign-in button", () => {
+    renderWithRouter();
+    expect(screen.getByTestId("sign-in-button")).toBeInTheDocument();
+  });
+
+  it("calls signinRedirect when sign-in button is clicked", async () => {
+    const user = userEvent.setup();
+    renderWithRouter();
+
+    const signInButton = screen.getByTestId("sign-in-button");
+    await user.click(signInButton);
+
+    expect(mockSigninRedirect).toHaveBeenCalledTimes(1);
+  });
+
+  it("redirects to home when already authenticated", () => {
+    mockAuthState.isAuthenticated = true;
+
+    render(
+      <TestRouter initialEntries={["/sign-in"]}>
+        <Routes>
+          <Route path="/sign-in" element={<SignIn />} />
+          <Route
+            path="/"
+            element={<div data-testid="home-page">Home Page</div>}
+          />
+        </Routes>
+      </TestRouter>,
+    );
+
+    // Should redirect to home, not show sign-in UI
+    expect(screen.queryByTestId("sign-in")).not.toBeInTheDocument();
+    expect(screen.getByTestId("home-page")).toBeInTheDocument();
+  });
+
+  it("redirects to the 'from' location when already authenticated", () => {
+    mockAuthState.isAuthenticated = true;
+
+    render(
+      <TestRouter
+        initialEntries={[
+          { pathname: "/sign-in", state: { from: { pathname: "/files" } } },
+        ]}
+      >
+        <Routes>
+          <Route path="/sign-in" element={<SignIn />} />
+          <Route
+            path="/files"
+            element={<div data-testid="files-page">Files Page</div>}
+          />
+          <Route
+            path="/"
+            element={<div data-testid="home-page">Home Page</div>}
+          />
+        </Routes>
+      </TestRouter>,
+    );
+
+    // Should redirect to /files, not show sign-in UI or home
+    expect(screen.queryByTestId("sign-in")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("home-page")).not.toBeInTheDocument();
+    expect(screen.getByTestId("files-page")).toBeInTheDocument();
+  });
+});

--- a/spa/src/pages/sign-in/SignIn.tsx
+++ b/spa/src/pages/sign-in/SignIn.tsx
@@ -1,0 +1,83 @@
+import { useLocation, Navigate } from "react-router-dom";
+import { useAuth } from "react-oidc-context";
+import { Button } from "@/components/ui/button";
+
+export function SignIn() {
+  const auth = useAuth();
+  const location = useLocation();
+
+  // Get the page they were trying to access, or default to home
+  const from = (location.state as any)?.from?.pathname || "/";
+
+  const handleSignIn = () => {
+    auth.signinRedirect();
+  };
+
+  // If already authenticated, redirect immediately
+  if (auth.isAuthenticated) {
+    return <Navigate to={from} replace />;
+  }
+
+  return (
+    <div
+      data-testid="sign-in"
+      className="flex flex-col md:flex-row min-h-screen w-full bg-background"
+    >
+      {/* Left Sidebar - Hidden on mobile, shown on md+ screens */}
+      <div
+        data-testid="sign-in-sidebar"
+        className="hidden md:flex md:w-[400px] lg:w-[561px] bg-black text-white px-6 md:px-8 lg:px-10 py-12 md:py-24 lg:py-[150px] flex-col gap-4 lg:gap-[19px]"
+      >
+        <h1 className="font-roboto text-2xl md:text-3xl lg:text-[32px] font-extrabold leading-tight lg:leading-10">
+          STUF
+        </h1>
+        <div className="font-roboto text-base md:text-lg lg:text-xl leading-relaxed lg:leading-7">
+          <p data-testid="sign-in-description" className="mb-5">
+            STUF is a comprehensive system for secure file uploads developed by
+            Pyx.
+          </p>
+          <a
+            data-testid="sign-in-pyx-link"
+            href="https://pyx.io"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="underline hover:opacity-80"
+          >
+            Pyx Website
+          </a>
+        </div>
+      </div>
+
+      {/* Right Content Area */}
+      <div className="flex-1 flex items-center justify-center px-4 py-8 md:px-[10px] md:py-[10px]">
+        <div className="w-full max-w-[513px] p-6 md:p-[25px] bg-card rounded-md border border-foreground flex flex-col gap-8 md:gap-10">
+          {/* Mobile-only logo */}
+          <div
+            data-testid="sign-in-mobile-logo"
+            className="md:hidden text-center mb-4"
+          >
+            <h2 className="font-roboto text-2xl font-extrabold text-foreground">
+              STUF
+            </h2>
+          </div>
+
+          <h1
+            data-testid="sign-in-title"
+            className="hidden md:block font-heading text-2xl md:text-[30px] font-semibold leading-tight md:leading-9 text-card-foreground"
+          >
+            Sign in to STUF
+          </h1>
+
+          <Button
+            data-testid="sign-in-button"
+            onClick={handleSignIn}
+            className="w-full px-4 py-2 bg-[#D2BB2D] hover:bg-[#D2BB2D]/90 text-black font-medium"
+            size="default"
+          >
+            Sign in
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
This PR adds a dedicated sign-in page that integrates with the OIDC authentication flow. It introduces a responsive layout with a branded sidebar and mobile view, triggers OIDC signinRedirect() on user action, and automatically redirects authenticated users to their intended destination or home. Storybook stories and tests have been added.

<img width="1553" height="1005" alt="Screenshot 2025-10-29 at 3 43 04 pm" src="https://github.com/user-attachments/assets/02f2e33c-5081-497b-ad59-7697c29ccc75" />
<img width="1769" height="1047" alt="Screenshot 2025-10-29 at 3 34 26 pm" src="https://github.com/user-attachments/assets/68f9fade-da26-459a-b4e5-753b4a7c3138" />
