### PR TITLE
feat: add dashboard

### DIFF
--- a/docker/keycloak/data/import/realm-export.json
+++ b/docker/keycloak/data/import/realm-export.json
@@ -1,7 +1,7 @@
 {
   "realm": "stuf",
   "enabled": true,
-  "sslRequired": "external",
+  "sslRequired": "none",
   "registrationAllowed": false,
   "requiredCredentials": [ "password" ],
   "roles": {
@@ -25,6 +25,65 @@
     ]
   },
   "clientScopes": [
+    {
+      "name": "profile",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "true",
+        "display.on.consent.screen": "true"
+      },
+      "protocolMappers": [
+        {
+          "name": "given name",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-property-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.attribute": "firstName",
+            "claim.name": "given_name",
+            "jsonType.label": "String",
+            "id.token.claim": "true",
+            "access.token.claim": "true"
+          }
+        },
+        {
+          "name": "family name",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-property-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.attribute": "lastName",
+            "claim.name": "family_name",
+            "jsonType.label": "String",
+            "id.token.claim": "true",
+            "access.token.claim": "true"
+          }
+        }
+      ]
+    },
+    {
+      "name": "email",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "true",
+        "display.on.consent.screen": "true"
+      },
+      "protocolMappers": [
+        {
+          "name": "email",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-property-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.attribute": "email",
+            "claim.name": "email",
+            "jsonType.label": "String",
+            "id.token.claim": "true",
+            "access.token.claim": "true"
+          }
+        }
+      ]
+    },
     {
       "name": "stuf:access",
       "protocol": "openid-connect",
@@ -83,6 +142,9 @@
       "directAccessGrantsEnabled": true,
       "implicitFlowEnabled": false,
       "serviceAccountsEnabled": false,
+      "attributes": {
+        "post.logout.redirect.uris": "http://localhost:3000/*##http://localhost:3100/*"
+      },
       "defaultClientScopes": [
         "web-origins",
         "roles",

--- a/spa/.gitignore
+++ b/spa/.gitignore
@@ -1,3 +1,6 @@
 node_modules
 *storybook.log
 storybook-static
+
+# MSW
+mockServiceWorker.js

--- a/spa/.storybook/main.ts
+++ b/spa/.storybook/main.ts
@@ -13,5 +13,6 @@ const config: StorybookConfig = {
     name: "@storybook/react-vite",
     options: {},
   },
+  staticDirs: ["../public"],
 };
 export default config;

--- a/spa/.storybook/preview-head.html
+++ b/spa/.storybook/preview-head.html
@@ -1,0 +1,6 @@
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+<link
+  href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&display=swap"
+  rel="stylesheet"
+/>

--- a/spa/.storybook/preview.ts
+++ b/spa/.storybook/preview.ts
@@ -1,6 +1,10 @@
 import type { Preview } from "@storybook/react-vite";
 import { withThemeByClassName } from "@storybook/addon-themes";
+import { initialize, mswLoader } from "msw-storybook-addon";
 import "../src/index.css";
+
+// Initialize MSW
+initialize();
 
 const preview: Preview = {
   tags: ["autodocs"],
@@ -28,6 +32,7 @@ const preview: Preview = {
       defaultTheme: "light",
     }),
   ],
+  loaders: [mswLoader],
 };
 
 export default preview;

--- a/spa/src/components/collection/collections-grid/index.ts
+++ b/spa/src/components/collection/collections-grid/index.ts
@@ -1,0 +1,1 @@
+export { CollectionsGrid } from "./CollectionsGrid";

--- a/spa/src/components/collection/upload-button/UploadButton.tsx
+++ b/spa/src/components/collection/upload-button/UploadButton.tsx
@@ -18,7 +18,7 @@ export function UploadButton({ className, onClick }: UploadButtonProps) {
       data-testid="upload-button"
     >
       <img src="/icons/cloud_upload.svg" alt="Upload" width={24} height={24} />
-      <span className="text-primary-text text-sm font-medium font-['Inter'] leading-normal">
+      <span className="text-primary-text text-sm font-medium leading-normal">
         Add files
       </span>
     </Button>

--- a/spa/src/components/sidebar/Sidebar.stories.tsx
+++ b/spa/src/components/sidebar/Sidebar.stories.tsx
@@ -83,6 +83,7 @@ export const AdminUser: Story = {
       { id: "collection-d", name: "Collections D" },
     ],
     user: {
+      username: "c.reardon",
       name: "Cindy Reardon",
       email: "c.reardon@emailadress.com",
       roles: [UserRole.Admin],
@@ -104,6 +105,7 @@ export const RegularUser: Story = {
       { id: "collection-d", name: "Collections D" },
     ],
     user: {
+      username: "john.doe",
       name: "John Doe",
       email: "john.doe@example.com",
       roles: [UserRole.ProjectParticipant],
@@ -134,6 +136,7 @@ export const WithAvatar: Story = {
   args: {
     ...AdminUser.args,
     user: {
+      username: "c.reardon",
       name: "Cindy Reardon",
       email: "c.reardon@emailadress.com",
       roles: [UserRole.Admin],
@@ -147,6 +150,7 @@ export const EmptyCollections: Story = {
   args: {
     collections: [],
     user: {
+      username: "c.reardon",
       name: "Cindy Reardon",
       email: "c.reardon@emailadress.com",
       roles: [UserRole.Admin],
@@ -163,6 +167,7 @@ export const ManyCollections: Story = {
   args: {
     collections: [],
     user: {
+      username: "c.reardon",
       name: "Cindy Reardon",
       email: "c.reardon@emailadress.com",
       roles: [UserRole.Admin],
@@ -213,6 +218,7 @@ export const ManyCollections: Story = {
           onConfigClick={handleConfigClick}
           onLogout={handleLogout}
           user={{
+            username: "c.reardon",
             name: "Cindy Reardon",
             email: "c.reardon@emailadress.com",
             roles: [UserRole.Admin],
@@ -237,6 +243,7 @@ export const LongUserInfo: Story = {
   args: {
     ...AdminUser.args,
     user: {
+      username: "christina.marie.reardon-smith",
       name: "Christina Marie Reardon-Smith",
       email: "christina.marie.reardon-smith@verylongemailaddress.com",
       roles: [UserRole.Admin],

--- a/spa/src/components/sidebar/Sidebar.test.tsx
+++ b/spa/src/components/sidebar/Sidebar.test.tsx
@@ -11,6 +11,7 @@ const mockCollections: Collection[] = [
 ];
 
 const mockAdminUser: User = {
+  username: "c.reardon",
   name: "Cindy Reardon",
   email: "c.reardon@emailadress.com",
   roles: [UserRole.Admin],
@@ -18,6 +19,7 @@ const mockAdminUser: User = {
 };
 
 const mockRegularUser: User = {
+  username: "john.doe",
   name: "John Doe",
   email: "john.doe@example.com",
   roles: [UserRole.ProjectParticipant],
@@ -224,6 +226,7 @@ describe("Sidebar", () => {
 
   it("hides Configuration nav item for limited users", () => {
     const limitedUser: User = {
+      username: "limiteduser",
       name: "Limited User",
       email: "limited@example.com",
       roles: [UserRole.ProjectParticipant],

--- a/spa/src/components/sidebar/footer/SidebarFooter.stories.tsx
+++ b/spa/src/components/sidebar/footer/SidebarFooter.stories.tsx
@@ -42,6 +42,7 @@ type Story = StoryObj<typeof meta>;
 export const Default: Story = {
   args: {
     user: {
+      username: "c.reardon",
       name: "Cindy Reardon",
       email: "c.reardon@emailadress.com",
       roles: [UserRole.ProjectParticipant],
@@ -54,6 +55,7 @@ export const Default: Story = {
 export const WithAvatar: Story = {
   args: {
     user: {
+      username: "c.reardon",
       name: "Cindy Reardon",
       email: "c.reardon@emailadress.com",
       roles: [UserRole.ProjectParticipant],
@@ -67,6 +69,7 @@ export const WithAvatar: Story = {
 export const LongUserInfo: Story = {
   args: {
     user: {
+      username: "christina.marie.reardon-smith",
       name: "Christina Marie Reardon-Smith",
       email: "christina.marie.reardon-smith@verylongemailaddress.com",
       roles: [UserRole.ProjectParticipant],

--- a/spa/src/components/sidebar/footer/SidebarFooter.test.tsx
+++ b/spa/src/components/sidebar/footer/SidebarFooter.test.tsx
@@ -5,6 +5,7 @@ import { SidebarFooter } from "./SidebarFooter";
 import { UserRole, type User } from "@/types";
 
 const mockUser: User = {
+  username: "c.reardon",
   name: "Cindy Reardon",
   email: "c.reardon@emailadress.com",
   roles: [UserRole.ProjectParticipant],

--- a/spa/src/components/sidebar/mobile/MobileSidebar.stories.tsx
+++ b/spa/src/components/sidebar/mobile/MobileSidebar.stories.tsx
@@ -75,6 +75,7 @@ export const AdminUser: Story = {
       { id: "collection-d", name: "Collections D" },
     ],
     user: {
+      username: "c.reardon",
       name: "Cindy Reardon",
       email: "c.reardon@emailadress.com",
       roles: [UserRole.Admin],
@@ -96,6 +97,7 @@ export const RegularUser: Story = {
       { id: "collection-d", name: "Collections D" },
     ],
     user: {
+      username: "john.doe",
       name: "John Doe",
       email: "john.doe@example.com",
       roles: [UserRole.ProjectParticipant],
@@ -119,6 +121,7 @@ export const WithAvatar: Story = {
   args: {
     ...AdminUser.args,
     user: {
+      username: "c.reardon",
       name: "Cindy Reardon",
       email: "c.reardon@emailadress.com",
       roles: [UserRole.Admin],
@@ -132,6 +135,7 @@ export const ManyCollections: Story = {
   args: {
     collections: [],
     user: {
+      username: "c.reardon",
       name: "Cindy Reardon",
       email: "c.reardon@emailadress.com",
       roles: [UserRole.Admin],
@@ -182,6 +186,7 @@ export const ManyCollections: Story = {
           onConfigClick={handleConfigClick}
           onLogout={handleLogout}
           user={{
+            username: "c.reardon",
             name: "Cindy Reardon",
             email: "c.reardon@emailadress.com",
             roles: [UserRole.Admin],

--- a/spa/src/components/sidebar/mobile/MobileSidebar.test.tsx
+++ b/spa/src/components/sidebar/mobile/MobileSidebar.test.tsx
@@ -10,6 +10,7 @@ const mockCollections: Collection[] = [
 ];
 
 const mockUser: User = {
+  username: "c.reardon",
   name: "Cindy Reardon",
   email: "c.reardon@emailadress.com",
   roles: [UserRole.Admin],

--- a/spa/src/components/sidebar/profile/SidebarProfile.stories.tsx
+++ b/spa/src/components/sidebar/profile/SidebarProfile.stories.tsx
@@ -37,6 +37,7 @@ type Story = StoryObj<typeof meta>;
 export const Default: Story = {
   args: {
     user: {
+      username: "storyuser",
       name: faker.person.fullName(),
       email: faker.internet.email(),
       roles: [],
@@ -49,6 +50,7 @@ export const Default: Story = {
 export const WithPlaceholder: Story = {
   args: {
     user: {
+      username: "c.reardon",
       name: "Cindy Reardon",
       email: "c.reardon@emailadress.com",
       roles: [],
@@ -60,6 +62,7 @@ export const WithPlaceholder: Story = {
 export const TruncatedName: Story = {
   args: {
     user: {
+      username: "c.montgomery",
       name: "Dr. Christopher Alexander Montgomery Wellington III",
       email: "c.montgomery@example.com",
       roles: [],
@@ -72,6 +75,7 @@ export const TruncatedName: Story = {
 export const TruncatedEmail: Story = {
   args: {
     user: {
+      username: "jane.doe",
       name: "Jane Doe",
       email:
         "jane.doe.with.a.very.long.email.address@corporate-company-domain.com",
@@ -85,6 +89,7 @@ export const TruncatedEmail: Story = {
 export const BothTruncated: Story = {
   args: {
     user: {
+      username: "alexander.montgomery",
       name: "Dr. Alexander Christopher Montgomery Wellington",
       email: "alexander.christopher.montgomery@very-long-corporate-domain.com",
       roles: [],

--- a/spa/src/components/sidebar/profile/SidebarProfile.test.tsx
+++ b/spa/src/components/sidebar/profile/SidebarProfile.test.tsx
@@ -3,6 +3,7 @@ import { SidebarProfile } from "./SidebarProfile";
 import type { User } from "@/types";
 
 const mockUser: User = {
+  username: "john.doe",
   name: "John Doe",
   email: "john@example.com",
   roles: [],
@@ -33,6 +34,7 @@ describe("SidebarProfile", () => {
     render(
       <SidebarProfile
         user={{
+          username: "c.montgomery",
           name: "Dr. Christopher Alexander Montgomery Wellington III",
           email: "short@example.com",
           roles: [],
@@ -49,6 +51,7 @@ describe("SidebarProfile", () => {
     render(
       <SidebarProfile
         user={{
+          username: "jane.doe",
           name: "Jane Doe",
           email: "very.long.email.address@corporate-company-domain.com",
           roles: [],

--- a/spa/src/components/table/data-table/index.ts
+++ b/spa/src/components/table/data-table/index.ts
@@ -1,2 +1,2 @@
 export { DataTable } from "./DataTable";
-export type { DataTableProps, Column } from "./DataTable";
+export type { DataTableProps } from "./DataTable";

--- a/spa/src/components/table/file-actions/FileActions.stories.tsx
+++ b/spa/src/components/table/file-actions/FileActions.stories.tsx
@@ -1,0 +1,212 @@
+import type { File } from "@/types";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import React from "react";
+import { AuthContext, type AuthContextProps } from "react-oidc-context";
+import { FileActions } from "./FileActions";
+
+// Mock Auth Context Provider
+function MockAuthProvider({
+  children,
+  username = "john.doe@example.com",
+  collections = {},
+}: {
+  children: React.ReactNode;
+  username?: string;
+  collections?: Record<string, string[]>;
+}) {
+  const mockAuthContext = {
+    user: {
+      profile: {
+        preferred_username: username,
+        email: username,
+        given_name: "John",
+        family_name: "Doe",
+        collections,
+      },
+      access_token: "mock-token",
+      token_type: "Bearer",
+      expires_at: Date.now() + 3600000,
+    },
+    isAuthenticated: true,
+    isLoading: false,
+    error: undefined,
+    settings: {},
+    signinRedirect: async () => {},
+    signoutRedirect: async () => {},
+    signinSilent: async () => {},
+    removeUser: async () => {},
+    clearStaleState: async () => {},
+    querySessionStatus: async () => {},
+    revokeTokens: async () => {},
+    startSilentRenew: () => {},
+    stopSilentRenew: () => {},
+  };
+
+  return (
+    <AuthContext.Provider
+      value={mockAuthContext as unknown as AuthContextProps}
+    >
+      {children}
+    </AuthContext.Provider>
+  );
+}
+
+// Helper to create a mock file
+const createMockFile = (overrides?: Partial<File>): File => ({
+  object_name: "example-document.pdf",
+  collection: "test-collection",
+  owner: "john.doe@example.com",
+  original_filename: "Example Document.pdf",
+  upload_time: "2024-01-15T10:30:00Z",
+  content_type: "application/pdf",
+  size: 2048576, // 2MB
+  ...overrides,
+});
+
+const meta: Meta<typeof FileActions> = {
+  title: "Components/Table/FileActions",
+  component: FileActions,
+  parameters: {
+    layout: "centered",
+    docs: {
+      description: {
+        component:
+          "A dropdown menu component for file actions. Displays different action options based on user permissions.",
+      },
+    },
+  },
+  decorators: [
+    (Story) => {
+      return (
+        <div className="bg-background p-8">
+          <div className="flex justify-center items-center">
+            <Story />
+          </div>
+        </div>
+      );
+    },
+  ],
+  tags: ["autodocs"],
+  args: {
+    file: createMockFile(),
+  },
+  argTypes: {
+    file: {
+      description: "The file object containing metadata",
+      control: "object",
+    },
+    onDownload: {
+      description: "Callback fired when Download is clicked",
+      action: "download",
+    },
+    onDelete: {
+      description: "Callback fired when Delete is clicked",
+      action: "delete",
+    },
+    onViewHistory: {
+      description: "Optional callback fired when View History is clicked",
+      action: "viewHistory",
+    },
+    onArchive: {
+      description: "Optional callback fired when Archive is clicked",
+      action: "archive",
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+// Full permissions - all actions available
+export const FullPermissions: Story = {
+  decorators: [
+    (Story) => (
+      <MockAuthProvider
+        username="john.doe@example.com"
+        collections={{
+          "test-collection": ["read", "write", "delete"],
+        }}
+      >
+        <Story />
+      </MockAuthProvider>
+    ),
+  ],
+  args: {
+    onDownload: (file) =>
+      console.log("Download clicked:", file.original_filename),
+    onDelete: (file) => console.log("Delete clicked:", file.original_filename),
+    onViewHistory: (file) =>
+      console.log("View History clicked:", file.original_filename),
+    onArchive: (file) =>
+      console.log("Archive clicked:", file.original_filename),
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "User has full permissions (canDelete). Shows Download, View History, Archive, and Delete options.",
+      },
+    },
+  },
+};
+
+// Download only permissions
+export const DownloadOnly: Story = {
+  decorators: [
+    (Story) => (
+      <MockAuthProvider
+        username="john.doe@example.com"
+        collections={{
+          "test-collection": ["read"],
+        }}
+      >
+        <Story />
+      </MockAuthProvider>
+    ),
+  ],
+  args: {
+    onDownload: (file) =>
+      console.log("Download clicked:", file.original_filename),
+    onDelete: (file) => console.log("Delete clicked:", file.original_filename),
+    onViewHistory: (file) =>
+      console.log("View History clicked:", file.original_filename),
+    onArchive: (file) =>
+      console.log("Archive clicked:", file.original_filename),
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "User has download-only permissions (read permission). Shows only Download option.",
+      },
+    },
+  },
+};
+
+// No permissions
+export const NoPermissions: Story = {
+  decorators: [
+    (Story) => (
+      <MockAuthProvider username="john.doe@example.com" collections={{}}>
+        <Story />
+      </MockAuthProvider>
+    ),
+  ],
+  args: {
+    onDownload: (file) =>
+      console.log("Download clicked:", file.original_filename),
+    onDelete: (file) => console.log("Delete clicked:", file.original_filename),
+    onViewHistory: (file) =>
+      console.log("View History clicked:", file.original_filename),
+    onArchive: (file) =>
+      console.log("Archive clicked:", file.original_filename),
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'User has no permissions. Shows disabled "No actions available" option.',
+      },
+    },
+  },
+};

--- a/spa/src/components/table/file-actions/FileActions.test.tsx
+++ b/spa/src/components/table/file-actions/FileActions.test.tsx
@@ -1,0 +1,360 @@
+import { useFilePermissions } from "@/hooks/file/useFilePermissions/useFilePermissions";
+import type { File } from "@/types";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { FileActions } from "./FileActions";
+
+// Mock the useFilePermissions hook
+vi.mock("@/hooks/file/useFilePermissions/useFilePermissions", () => ({
+  useFilePermissions: vi.fn(),
+}));
+
+// Helper to create a mock file
+function createMockFile(overrides?: Partial<File>): File {
+  return {
+    object_name: "test-file.txt",
+    collection: "test-collection",
+    owner: "test@example.com",
+    original_filename: "test-file.txt",
+    upload_time: "2024-01-01T00:00:00Z",
+    content_type: "text/plain",
+    size: 1024,
+    ...overrides,
+  };
+}
+
+describe("FileActions", () => {
+  const mockOnDownload = vi.fn();
+  const mockOnDelete = vi.fn();
+  const mockOnViewHistory = vi.fn();
+  const mockOnArchive = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("with full permissions (canDelete)", () => {
+    beforeEach(() => {
+      vi.mocked(useFilePermissions).mockReturnValue({
+        canRead: true,
+        canWrite: true,
+        canDelete: true,
+        canDownload: true,
+        canArchive: true,
+        canViewHistory: true,
+        isOwnFile: true,
+      });
+    });
+
+    it("renders all action options when all handlers provided", async () => {
+      const user = userEvent.setup();
+      const file = createMockFile();
+
+      render(
+        <FileActions
+          file={file}
+          onDownload={mockOnDownload}
+          onDelete={mockOnDelete}
+          onViewHistory={mockOnViewHistory}
+          onArchive={mockOnArchive}
+        />,
+      );
+
+      const trigger = screen.getByTestId("more-options-trigger");
+      await user.click(trigger);
+
+      expect(screen.getByTestId("more-options-content")).toBeInTheDocument();
+      expect(screen.getByTestId("more-options-option-0-0")).toHaveTextContent(
+        "Download",
+      );
+      expect(screen.getByTestId("more-options-option-0-1")).toHaveTextContent(
+        "View History",
+      );
+      expect(screen.getByTestId("more-options-option-0-2")).toHaveTextContent(
+        "Archive",
+      );
+      expect(screen.getByTestId("more-options-option-1-0")).toHaveTextContent(
+        "Delete",
+      );
+    });
+
+    it("omits View History when handler not provided", async () => {
+      const user = userEvent.setup();
+      const file = createMockFile();
+
+      render(
+        <FileActions
+          file={file}
+          onDownload={mockOnDownload}
+          onDelete={mockOnDelete}
+          onArchive={mockOnArchive}
+        />,
+      );
+
+      const trigger = screen.getByTestId("more-options-trigger");
+      await user.click(trigger);
+
+      expect(screen.getByTestId("more-options-content")).toBeInTheDocument();
+      expect(screen.getByTestId("more-options-option-0-0")).toHaveTextContent(
+        "Download",
+      );
+      expect(screen.queryByText("View History")).not.toBeInTheDocument();
+      expect(screen.getByTestId("more-options-option-0-1")).toHaveTextContent(
+        "Archive",
+      );
+      expect(screen.getByTestId("more-options-option-1-0")).toHaveTextContent(
+        "Delete",
+      );
+    });
+
+    it("omits Archive when handler not provided", async () => {
+      const user = userEvent.setup();
+      const file = createMockFile();
+
+      render(
+        <FileActions
+          file={file}
+          onDownload={mockOnDownload}
+          onDelete={mockOnDelete}
+          onViewHistory={mockOnViewHistory}
+        />,
+      );
+
+      const trigger = screen.getByTestId("more-options-trigger");
+      await user.click(trigger);
+
+      expect(screen.getByTestId("more-options-content")).toBeInTheDocument();
+      expect(screen.getByTestId("more-options-option-0-0")).toHaveTextContent(
+        "Download",
+      );
+      expect(screen.getByTestId("more-options-option-0-1")).toHaveTextContent(
+        "View History",
+      );
+      expect(screen.queryByText("Archive")).not.toBeInTheDocument();
+      expect(screen.getByTestId("more-options-option-1-0")).toHaveTextContent(
+        "Delete",
+      );
+    });
+
+    it("calls onDownload with correct file when Download clicked", async () => {
+      const user = userEvent.setup();
+      const file = createMockFile();
+
+      render(
+        <FileActions
+          file={file}
+          onDownload={mockOnDownload}
+          onDelete={mockOnDelete}
+        />,
+      );
+
+      await user.click(screen.getByTestId("more-options-trigger"));
+      const downloadOption = screen.getByTestId("more-options-option-0-0");
+      expect(downloadOption).toHaveTextContent("Download");
+      await user.click(downloadOption);
+
+      expect(mockOnDownload).toHaveBeenCalledWith(file);
+      expect(mockOnDownload).toHaveBeenCalledTimes(1);
+    });
+
+    it("calls onViewHistory with correct file when View History clicked", async () => {
+      const user = userEvent.setup();
+      const file = createMockFile();
+
+      render(
+        <FileActions
+          file={file}
+          onDownload={mockOnDownload}
+          onDelete={mockOnDelete}
+          onViewHistory={mockOnViewHistory}
+        />,
+      );
+
+      await user.click(screen.getByTestId("more-options-trigger"));
+      const viewHistoryOption = screen.getByTestId("more-options-option-0-1");
+      expect(viewHistoryOption).toHaveTextContent("View History");
+      await user.click(viewHistoryOption);
+
+      expect(mockOnViewHistory).toHaveBeenCalledWith(file);
+      expect(mockOnViewHistory).toHaveBeenCalledTimes(1);
+    });
+
+    it("calls onArchive with correct file when Archive clicked", async () => {
+      const user = userEvent.setup();
+      const file = createMockFile();
+
+      render(
+        <FileActions
+          file={file}
+          onDownload={mockOnDownload}
+          onDelete={mockOnDelete}
+          onArchive={mockOnArchive}
+        />,
+      );
+
+      await user.click(screen.getByTestId("more-options-trigger"));
+      const archiveOption = screen.getByTestId("more-options-option-0-1");
+      expect(archiveOption).toHaveTextContent("Archive");
+      await user.click(archiveOption);
+
+      expect(mockOnArchive).toHaveBeenCalledWith(file);
+      expect(mockOnArchive).toHaveBeenCalledTimes(1);
+    });
+
+    it("calls onDelete with correct file when Delete clicked", async () => {
+      const user = userEvent.setup();
+      const file = createMockFile();
+
+      render(
+        <FileActions
+          file={file}
+          onDownload={mockOnDownload}
+          onDelete={mockOnDelete}
+        />,
+      );
+
+      await user.click(screen.getByTestId("more-options-trigger"));
+      const deleteOption = screen.getByTestId("more-options-option-1-0");
+      expect(deleteOption).toHaveTextContent("Delete");
+      await user.click(deleteOption);
+
+      expect(mockOnDelete).toHaveBeenCalledWith(file);
+      expect(mockOnDelete).toHaveBeenCalledTimes(1);
+    });
+
+    it("renders Delete option with destructive styling", async () => {
+      const user = userEvent.setup();
+      const file = createMockFile();
+
+      render(
+        <FileActions
+          file={file}
+          onDownload={mockOnDownload}
+          onDelete={mockOnDelete}
+        />,
+      );
+
+      await user.click(screen.getByTestId("more-options-trigger"));
+
+      // The Delete option should be in the second group (index 1, option 0)
+      const deleteOption = screen.getByTestId("more-options-option-1-0");
+      expect(deleteOption).toHaveClass("text-destructive");
+    });
+  });
+
+  describe("with download-only permissions (canDownload)", () => {
+    beforeEach(() => {
+      vi.mocked(useFilePermissions).mockReturnValue({
+        canRead: true,
+        canWrite: false,
+        canDelete: false,
+        canDownload: true,
+        canArchive: false,
+        canViewHistory: false,
+        isOwnFile: false,
+      });
+    });
+
+    it("renders only Download option", async () => {
+      const user = userEvent.setup();
+      const file = createMockFile();
+
+      render(
+        <FileActions
+          file={file}
+          onDownload={mockOnDownload}
+          onDelete={mockOnDelete}
+          onViewHistory={mockOnViewHistory}
+          onArchive={mockOnArchive}
+        />,
+      );
+
+      await user.click(screen.getByTestId("more-options-trigger"));
+
+      expect(screen.getByTestId("more-options-content")).toBeInTheDocument();
+      expect(screen.getByTestId("more-options-option-0-0")).toHaveTextContent(
+        "Download",
+      );
+      expect(screen.queryByText("View History")).not.toBeInTheDocument();
+      expect(screen.queryByText("Archive")).not.toBeInTheDocument();
+      expect(screen.queryByText("Delete")).not.toBeInTheDocument();
+    });
+
+    it("calls onDownload when Download clicked", async () => {
+      const user = userEvent.setup();
+      const file = createMockFile();
+
+      render(
+        <FileActions
+          file={file}
+          onDownload={mockOnDownload}
+          onDelete={mockOnDelete}
+        />,
+      );
+
+      await user.click(screen.getByTestId("more-options-trigger"));
+      const downloadOption = screen.getByTestId("more-options-option-0-0");
+      expect(downloadOption).toHaveTextContent("Download");
+      await user.click(downloadOption);
+
+      expect(mockOnDownload).toHaveBeenCalledWith(file);
+      expect(mockOnDownload).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("with no permissions", () => {
+    beforeEach(() => {
+      vi.mocked(useFilePermissions).mockReturnValue({
+        canRead: false,
+        canWrite: false,
+        canDelete: false,
+        canDownload: false,
+        canArchive: false,
+        canViewHistory: false,
+        isOwnFile: false,
+      });
+    });
+
+    it("renders only disabled 'No actions available' option", async () => {
+      const user = userEvent.setup();
+      const file = createMockFile();
+
+      render(
+        <FileActions
+          file={file}
+          onDownload={mockOnDownload}
+          onDelete={mockOnDelete}
+        />,
+      );
+
+      await user.click(screen.getByTestId("more-options-trigger"));
+
+      expect(screen.getByTestId("more-options-content")).toBeInTheDocument();
+      expect(screen.getByTestId("more-options-option-0-0")).toHaveTextContent(
+        "No actions available",
+      );
+      expect(screen.queryByText("Download")).not.toBeInTheDocument();
+      expect(screen.queryByText("Delete")).not.toBeInTheDocument();
+    });
+
+    it("renders disabled option with correct attributes", async () => {
+      const user = userEvent.setup();
+      const file = createMockFile();
+
+      render(
+        <FileActions
+          file={file}
+          onDownload={mockOnDownload}
+          onDelete={mockOnDelete}
+        />,
+      );
+
+      await user.click(screen.getByTestId("more-options-trigger"));
+
+      const option = screen.getByTestId("more-options-option-0-0");
+      expect(option).toHaveAttribute("data-disabled");
+      expect(option).toHaveAttribute("aria-disabled", "true");
+    });
+  });
+});

--- a/spa/src/components/table/file-actions/FileActions.tsx
+++ b/spa/src/components/table/file-actions/FileActions.tsx
@@ -1,0 +1,95 @@
+import {
+  MoreOptionGroup,
+  MoreOptions,
+} from "@/components/utility/more-options";
+import { useFilePermissions } from "@/hooks/file/useFilePermissions";
+import type { File } from "@/types";
+import { useMemo } from "react";
+
+export interface FileActionsProps {
+  file: File;
+  onDownload: (file: File) => void;
+  onDelete: (file: File) => void;
+  onViewHistory?: (file: File) => void;
+  onArchive?: (file: File) => void;
+}
+
+export function FileActions({
+  file,
+  onDownload,
+  onDelete,
+  onViewHistory,
+  onArchive,
+}: FileActionsProps) {
+  const permissions = useFilePermissions(file);
+
+  const groups: MoreOptionGroup[] = useMemo(() => {
+    if (permissions.canDelete) {
+      // Full access
+      return [
+        {
+          options: [
+            {
+              label: "Download",
+              onClick: () => onDownload(file),
+            },
+            ...(onViewHistory
+              ? [
+                  {
+                    label: "View History",
+                    onClick: () => onViewHistory(file),
+                  },
+                ]
+              : []),
+            ...(onArchive
+              ? [
+                  {
+                    label: "Archive",
+                    onClick: () => onArchive(file),
+                  },
+                ]
+              : []),
+          ],
+        },
+        {
+          options: [
+            {
+              label: "Delete",
+              onClick: () => onDelete(file),
+              destructive: true,
+            },
+          ],
+        },
+      ];
+    }
+
+    if (permissions.canDownload) {
+      // Can download
+      return [
+        {
+          options: [
+            {
+              label: "Download",
+              onClick: () => onDownload(file),
+            },
+          ],
+        },
+      ];
+    }
+
+    // No actions available
+    return [
+      {
+        options: [
+          {
+            label: "No actions available",
+            onClick: () => {},
+            disabled: true,
+          },
+        ],
+      },
+    ];
+  }, [permissions, file, onDownload, onDelete, onViewHistory, onArchive]);
+
+  return <MoreOptions groups={groups} />;
+}

--- a/spa/src/components/table/file-actions/index.ts
+++ b/spa/src/components/table/file-actions/index.ts
@@ -1,0 +1,1 @@
+export * from "./FileActions";

--- a/spa/src/components/table/recent-files-table/RecentFilesTable.stories.tsx
+++ b/spa/src/components/table/recent-files-table/RecentFilesTable.stories.tsx
@@ -1,0 +1,226 @@
+import type { File } from "@/types";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import React from "react";
+import { AuthContext, type AuthContextProps } from "react-oidc-context";
+import { RecentFilesTable } from "./RecentFilesTable";
+
+const meta: Meta<typeof RecentFilesTable> = {
+  title: "Components/Table/RecentFilesTable",
+  component: RecentFilesTable,
+  parameters: {
+    layout: "padded",
+  },
+  decorators: [
+    (Story) => (
+      <div className="bg-background">
+        <Story />
+      </div>
+    ),
+  ],
+  tags: ["autodocs"],
+  argTypes: {
+    files: {
+      control: "object",
+      description: "Array of file objects to display in the table",
+    },
+    loading: {
+      control: "boolean",
+      description: "Whether the table is in a loading state",
+    },
+    onDownload: {
+      action: "download clicked",
+      description: "Callback when download action is clicked",
+    },
+    onDelete: {
+      action: "delete clicked",
+      description: "Callback when delete action is clicked",
+    },
+    onViewHistory: {
+      action: "view history clicked",
+      description: "Optional callback when view history action is clicked",
+    },
+    onArchive: {
+      action: "archive clicked",
+      description: "Optional callback when archive action is clicked",
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof RecentFilesTable>;
+
+// Mock Auth Context Provider
+function MockAuthProvider({
+  children,
+  username = "user1",
+  collections = {},
+}: {
+  children: React.ReactNode;
+  username?: string;
+  collections?: Record<string, string[]>;
+}) {
+  const mockAuthContext = {
+    user: {
+      profile: {
+        preferred_username: username,
+        email: `${username}@example.com`,
+        given_name: username.charAt(0).toUpperCase() + username.slice(1),
+        family_name: "User",
+        collections,
+      },
+      access_token: "mock-token",
+      token_type: "Bearer",
+      expires_at: Date.now() + 3600000,
+    },
+    isAuthenticated: true,
+    isLoading: false,
+    error: undefined,
+    settings: {},
+    signinRedirect: async () => {},
+    signoutRedirect: async () => {},
+    signinSilent: async () => {},
+    removeUser: async () => {},
+    clearStaleState: async () => {},
+    querySessionStatus: async () => {},
+    revokeTokens: async () => {},
+    startSilentRenew: () => {},
+    stopSilentRenew: () => {},
+  };
+
+  return (
+    <AuthContext.Provider
+      value={mockAuthContext as unknown as AuthContextProps}
+    >
+      {children}
+    </AuthContext.Provider>
+  );
+}
+
+const mockFiles: File[] = [
+  {
+    object_name: "collection-a/user1/annual-report.pdf",
+    collection: "collection-a",
+    owner: "Cindy Reardon",
+    original_filename: "Annual reporting of the lorem ipsum dolar sit amet",
+    upload_time: "2025-01-23T20:58:00Z",
+    content_type: "application/pdf",
+    size: 24 * 1024 * 1024,
+    metadata: { status: "In progress" },
+  },
+  {
+    object_name: "collection-b/user2/changelog.pdf",
+    collection: "collection-b",
+    owner: "Melville Frohicky",
+    original_filename: "Change log of the lorem ipsum dolar sit amet",
+    upload_time: "2025-02-08T09:01:00Z",
+    content_type: "application/pdf",
+    size: 24 * 1024 * 1024,
+    metadata: { status: "In progress" },
+  },
+  {
+    object_name: "collection-c/user3/board-meeting.pdf",
+    collection: "collection-c",
+    owner: "e.tombs@longeremailaddress",
+    original_filename: "Board Meeting Q3 2025",
+    upload_time: "2025-03-11T12:15:00Z",
+    content_type: "application/pdf",
+    size: 38 * 1024 * 1024,
+    metadata: { status: "Review" },
+  },
+  {
+    object_name: "collection-a/user4/report.pdf",
+    collection: "collection-a",
+    owner: "Cassandra Spender",
+    original_filename: "Mandatory reporting Q1 2024 to Q4 2025",
+    upload_time: "2025-05-10T12:28:00Z",
+    content_type: "application/pdf",
+    size: 1.4 * 1024 * 1024,
+    metadata: { status: "Done" },
+  },
+];
+
+export const Default: Story = {
+  decorators: [
+    (Story) => (
+      <MockAuthProvider
+        username="Cindy Reardon"
+        collections={{
+          "collection-a": ["read", "write", "delete"],
+          "collection-b": ["read", "write", "delete"],
+          "collection-c": ["read", "write", "delete"],
+        }}
+      >
+        <Story />
+      </MockAuthProvider>
+    ),
+  ],
+  args: {
+    files: mockFiles,
+    loading: false,
+    onDownload: (file) => console.log("Download:", file.original_filename),
+    onDelete: (file) => console.log("Delete:", file.original_filename),
+    onViewHistory: (file) =>
+      console.log("View history:", file.original_filename),
+    onArchive: (file) => console.log("Archive:", file.original_filename),
+  },
+};
+
+export const Loading: Story = {
+  decorators: [
+    (Story) => (
+      <MockAuthProvider>
+        <Story />
+      </MockAuthProvider>
+    ),
+  ],
+  args: {
+    files: [],
+    loading: true,
+    onDownload: () => {},
+    onDelete: () => {},
+    onViewHistory: () => {},
+    onArchive: () => {},
+  },
+};
+
+export const Empty: Story = {
+  decorators: [
+    (Story) => (
+      <MockAuthProvider>
+        <Story />
+      </MockAuthProvider>
+    ),
+  ],
+  args: {
+    files: [],
+    loading: false,
+    onDownload: () => {},
+    onDelete: () => {},
+    onViewHistory: () => {},
+    onArchive: () => {},
+  },
+};
+
+export const SingleFile: Story = {
+  decorators: [
+    (Story) => (
+      <MockAuthProvider
+        username="Cindy Reardon"
+        collections={{
+          "collection-a": ["read", "write", "delete"],
+        }}
+      >
+        <Story />
+      </MockAuthProvider>
+    ),
+  ],
+  args: {
+    files: [mockFiles[0]],
+    loading: false,
+    onDownload: (file) => console.log("Download:", file.original_filename),
+    onDelete: (file) => console.log("Delete:", file.original_filename),
+    onViewHistory: (file) =>
+      console.log("View history:", file.original_filename),
+    onArchive: (file) => console.log("Archive:", file.original_filename),
+  },
+};

--- a/spa/src/components/table/recent-files-table/RecentFilesTable.test.tsx
+++ b/spa/src/components/table/recent-files-table/RecentFilesTable.test.tsx
@@ -1,0 +1,159 @@
+import type { File, User } from "@/types";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { RecentFilesTable } from "./RecentFilesTable";
+
+// Mock the useAuth hook
+vi.mock("react-oidc-context", async () => {
+  const actual = await vi.importActual("react-oidc-context");
+  return {
+    ...actual,
+    useAuth: () => ({
+      isAuthenticated: true,
+      isLoading: false,
+      user: {
+        profile: {
+          email: "test@example.com",
+          name: "Test User",
+          preferred_username: "testuser",
+          collections: JSON.stringify({
+            "collection-a": ["read", "write", "delete"],
+            "collection-b": ["read", "write", "delete"],
+          }),
+        },
+      },
+    }),
+  };
+});
+
+describe("RecentFilesTable", () => {
+  const mockUser: User = {
+    username: "testuser",
+    email: "test@example.com",
+    name: "Test User",
+    collections: {
+      "collection-a": ["read", "write", "delete"],
+      "collection-b": ["read", "write", "delete"],
+    },
+    roles: [],
+  };
+
+  const mockFiles: File[] = [
+    {
+      object_name: "collection-a/user1/file1.pdf",
+      collection: "collection-a",
+      owner: "John Doe",
+      original_filename: "Test File 1",
+      upload_time: "2025-01-15T10:00:00Z",
+      content_type: "application/pdf",
+      size: 1024 * 1024,
+      metadata: {},
+    },
+    {
+      object_name: "collection-b/user2/file2.pdf",
+      collection: "collection-b",
+      owner: "Jane Smith",
+      original_filename: "Test File 2",
+      upload_time: "2025-01-16T11:00:00Z",
+      content_type: "application/pdf",
+      size: 2 * 1024 * 1024,
+      metadata: {},
+    },
+  ];
+
+  const defaultProps = {
+    files: mockFiles,
+    user: mockUser,
+    loading: false,
+    onDownload: vi.fn(),
+    onDelete: vi.fn(),
+  };
+
+  it("renders table with files", () => {
+    render(<RecentFilesTable {...defaultProps} />);
+
+    expect(screen.getByTestId("recent-files-table")).toBeInTheDocument();
+    expect(screen.getByText("Test File 1")).toBeInTheDocument();
+    expect(screen.getByText("Test File 2")).toBeInTheDocument();
+    expect(screen.getByTestId("recent-files-table-row-0")).toBeInTheDocument();
+    expect(screen.getByTestId("recent-files-table-row-1")).toBeInTheDocument();
+  });
+
+  it("displays empty message when no files", () => {
+    render(<RecentFilesTable {...defaultProps} files={[]} />);
+
+    expect(screen.getByTestId("recent-files-table")).toBeInTheDocument();
+    expect(
+      screen.getByTestId("recent-files-table-empty-row"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId("recent-files-table-empty-message"),
+    ).toHaveTextContent("No recent files");
+  });
+
+  it("shows loading state", () => {
+    render(<RecentFilesTable {...defaultProps} loading={true} />);
+
+    // Should show skeleton rows
+    expect(screen.getByTestId("recent-files-table")).toBeInTheDocument();
+    expect(
+      screen.getByTestId("recent-files-table-skeleton-row-0"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId("recent-files-table-skeleton-row-1"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId("recent-files-table-skeleton-row-2"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId("recent-files-table-skeleton-row-3"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId("recent-files-table-skeleton-row-4"),
+    ).toBeInTheDocument();
+  });
+
+  it("allows sorting by different fields", async () => {
+    const user = userEvent.setup();
+    render(<RecentFilesTable {...defaultProps} />);
+
+    const sortTrigger = screen.getByTestId("recent-files-table-sort");
+    expect(sortTrigger).toBeInTheDocument();
+
+    // Click to open the dropdown
+    await user.click(sortTrigger);
+
+    // Verify dropdown content is visible
+    expect(
+      screen.getByTestId("recent-files-table-sort-content"),
+    ).toBeInTheDocument();
+
+    // Select "Date" option
+    const dateOption = screen.getByTestId(
+      "recent-files-table-sort-option-date",
+    );
+    expect(dateOption).toBeInTheDocument();
+    await user.click(dateOption);
+
+    // Verify the sort was applied (sortBy state changed)
+    expect(sortTrigger).toBeInTheDocument();
+  });
+
+  it("formats file size correctly", () => {
+    render(<RecentFilesTable {...defaultProps} />);
+
+    expect(screen.getByTestId("recent-files-table")).toBeInTheDocument();
+
+    // Check the size column cells
+    const sizeCells = [
+      screen.getByTestId("recent-files-table-cell-0_size"),
+      screen.getByTestId("recent-files-table-cell-1_size"),
+    ];
+
+    // 1MB file
+    expect(sizeCells[0]).toHaveTextContent("1.0");
+    // 2MB file
+    expect(sizeCells[1]).toHaveTextContent("2.0");
+  });
+});

--- a/spa/src/components/table/recent-files-table/RecentFilesTable.tsx
+++ b/spa/src/components/table/recent-files-table/RecentFilesTable.tsx
@@ -1,0 +1,125 @@
+import { DataTable } from "@/components/table/data-table";
+import { FileActions } from "@/components/table/file-actions";
+import { TableSort } from "@/components/table/table-sort";
+import { sortOptions, useFilesSort } from "@/hooks/file/useFilesSort";
+import type { File } from "@/types";
+import type { FileSortField } from "@/types/services/files";
+import { ColumnDef } from "@tanstack/react-table";
+
+export interface RecentFilesTableProps {
+  files: File[];
+  loading?: boolean;
+  onDownload: (file: File) => void;
+  onDelete: (file: File) => void;
+  onViewHistory?: (file: File) => void;
+  onArchive?: (file: File) => void;
+}
+
+export function RecentFilesTable({
+  files,
+  loading = false,
+  onDownload,
+  onDelete,
+  onViewHistory,
+  onArchive,
+}: RecentFilesTableProps) {
+  const { sortedFiles, sortBy, setSortBy } = useFilesSort(files);
+
+  const columns: ColumnDef<File>[] = [
+    {
+      accessorKey: "original_filename",
+      header: "Name",
+      cell: ({ row }) => (
+        <div className="flex-1">{row.getValue("original_filename")}</div>
+      ),
+    },
+    {
+      accessorKey: "upload_time",
+      header: "Upload date and time",
+      cell: ({ row }) => {
+        const date = new Date(row.getValue("upload_time"));
+        return (
+          <div>
+            {date.toLocaleDateString("en-GB", {
+              day: "2-digit",
+              month: "2-digit",
+              year: "numeric",
+            })}{" "}
+            {date.toLocaleTimeString("en-GB", {
+              hour: "2-digit",
+              minute: "2-digit",
+              hour12: true,
+            })}
+          </div>
+        );
+      },
+    },
+    {
+      accessorKey: "owner",
+      header: "Uploader",
+    },
+    {
+      accessorKey: "size",
+      header: "Size (mb)",
+      cell: ({ row }) => {
+        const size = row.getValue("size") as number | undefined;
+        if (!size) return "-";
+        return (size / (1024 * 1024)).toFixed(1);
+      },
+    },
+    {
+      accessorKey: "metadata",
+      header: "Status",
+      cell: ({ row }) => {
+        const metadata = row.getValue("metadata") as Record<string, any>;
+        return metadata?.status || "In progress";
+      },
+    },
+    {
+      id: "actions",
+      header: "",
+      cell: ({ row }) => (
+        <FileActions
+          file={row.original}
+          onDownload={onDownload}
+          onDelete={onDelete}
+          onViewHistory={onViewHistory}
+          onArchive={onArchive}
+        />
+      ),
+    },
+  ];
+
+  const handleSortChange = (value: string) => {
+    setSortBy(value as FileSortField);
+  };
+
+  return (
+    <div className="flex flex-col gap-6">
+      <div className="flex justify-between items-start">
+        <h2 className="text-2xl font-semibold font-['Roboto'] leading-loose text-foreground">
+          Recent files
+        </h2>
+        <TableSort
+          value={sortBy}
+          onValueChange={handleSortChange}
+          options={sortOptions}
+          testId="recent-files-table-sort"
+          isLoading={loading}
+        />
+      </div>
+
+      <div className="overflow-x-auto">
+        <div className="min-w-[800px]">
+          <DataTable
+            columns={columns}
+            data={sortedFiles}
+            isLoading={loading}
+            emptyMessage="No recent files"
+            testId="recent-files-table"
+          />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/spa/src/components/table/recent-files-table/index.ts
+++ b/spa/src/components/table/recent-files-table/index.ts
@@ -1,0 +1,1 @@
+export * from "./RecentFilesTable";

--- a/spa/src/components/table/table-sort/TableSort.stories.tsx
+++ b/spa/src/components/table/table-sort/TableSort.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { useState } from "react";
-import { TableSort, SortOption } from "./TableSort";
+import { SortOption, TableSort } from "./TableSort";
 
 const meta: Meta<typeof TableSort> = {
   title: "Components/Table/TableSort",
@@ -22,6 +22,36 @@ const meta: Meta<typeof TableSort> = {
     },
   ],
   tags: ["autodocs"],
+  argTypes: {
+    value: {
+      control: "text",
+      description: "Currently selected sort value",
+    },
+    onValueChange: {
+      action: "value changed",
+      description: "Callback when sort value changes",
+    },
+    options: {
+      control: "object",
+      description: "Array of sort options with value and label",
+    },
+    placeholder: {
+      control: "text",
+      description: "Placeholder text when no value is selected",
+    },
+    className: {
+      control: "text",
+      description: "Additional CSS classes to apply to the trigger",
+    },
+    testId: {
+      control: "text",
+      description: "Test ID for the component (default: 'table-sort')",
+    },
+    isLoading: {
+      control: "boolean",
+      description: "Whether the component is in a loading state",
+    },
+  },
 };
 
 export default meta;

--- a/spa/src/components/table/table-sort/TableSort.test.tsx
+++ b/spa/src/components/table/table-sort/TableSort.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { TableSort, SortOption } from "./TableSort";
+import { SortOption, TableSort } from "./TableSort";
 
 describe("TableSort", () => {
   const mockOnValueChange = vi.fn();

--- a/spa/src/components/table/table-sort/TableSort.tsx
+++ b/spa/src/components/table/table-sort/TableSort.tsx
@@ -5,6 +5,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import { Skeleton } from "@/components/ui/skeleton";
 import { cn } from "@/lib/utils";
 
 export interface SortOption {
@@ -19,6 +20,7 @@ export interface TableSortProps {
   placeholder?: string;
   className?: string;
   testId?: string;
+  isLoading?: boolean;
 }
 
 export function TableSort({
@@ -28,12 +30,17 @@ export function TableSort({
   placeholder = "Sort by",
   className,
   testId = "table-sort",
+  isLoading = false,
 }: TableSortProps) {
+  if (isLoading) {
+    return <Skeleton className="h-10 w-48" />;
+  }
+
   return (
     <Select value={value} onValueChange={onValueChange}>
       <SelectTrigger
         className={cn(
-          "w-48 px-3 py-2 bg-background rounded-md border border-input inline-flex justify-start items-center gap-2.5 focus:ring-0 focus:ring-offset-0 shadow-none [&_svg]:opacity-100 [&_svg]:text-foreground [&_svg]:stroke-[2.5] h-auto [&>span]:text-foreground [&>span]:text-sm [&>span]:font-normal [&>span]:font-['Inter'] [&>span]:leading-normal [&>span]:flex-1 [&>span]:text-left",
+          "w-48 px-3 py-2 bg-background rounded-md border border-input inline-flex justify-start items-center gap-2.5 focus:ring-0 focus:ring-offset-0 shadow-none [&_svg]:opacity-100 [&_svg]:text-foreground [&_svg]:stroke-[2.5] h-auto [&>span]:text-foreground [&>span]:text-sm [&>span]:font-normal [&>span]:leading-normal [&>span]:flex-1 [&>span]:text-left",
           className,
         )}
         data-testid={testId}
@@ -50,7 +57,7 @@ export function TableSort({
               key={option.value}
               value={option.value}
               className={cn(
-                "w-full px-2 py-1.5 flex justify-start items-center gap-2 rounded-none cursor-pointer focus:bg-accent hover:bg-accent border-0 outline-none text-sm font-medium font-['Inter'] leading-tight text-muted-foreground focus:text-muted-foreground data-[state=checked]:text-foreground [&>span.absolute]:hidden pr-2",
+                "w-full px-2 py-1.5 flex justify-start items-center gap-2 rounded-none cursor-pointer focus:bg-accent hover:bg-accent border-0 outline-none text-sm font-medium leading-tight text-muted-foreground focus:text-muted-foreground data-[state=checked]:text-foreground [&>span.absolute]:hidden pr-2",
                 index === 0 ? "mt-[5px]" : "",
                 index === options.length - 1 ? "mb-[5px]" : "",
               )}

--- a/spa/src/components/table/table-sort/index.ts
+++ b/spa/src/components/table/table-sort/index.ts
@@ -1,2 +1,1 @@
-export { TableSort } from "./TableSort";
-export type { TableSortProps, SortOption } from "./TableSort";
+export * from "./TableSort";

--- a/spa/src/contexts/collections/CollectionsContext.test.tsx
+++ b/spa/src/contexts/collections/CollectionsContext.test.tsx
@@ -27,6 +27,7 @@ function renderWithProvider() {
 
 describe("CollectionsContext", () => {
   const mockUser: User = {
+    username: "testuser",
     name: "Test User",
     email: "test@example.com",
     collections: {

--- a/spa/src/contexts/files/FilesContext.test.tsx
+++ b/spa/src/contexts/files/FilesContext.test.tsx
@@ -51,6 +51,7 @@ function renderWithProvider() {
 
 describe("FilesContext", () => {
   const mockUser: User = {
+    username: "testuser",
     name: "Test User",
     email: "test@example.com",
     collections: {

--- a/spa/src/hooks/file/index.ts
+++ b/spa/src/hooks/file/index.ts
@@ -1,0 +1,2 @@
+export * from "./useFileActions";
+export * from "./useFilesSort";

--- a/spa/src/hooks/file/useFileActions/index.ts
+++ b/spa/src/hooks/file/useFileActions/index.ts
@@ -1,0 +1,1 @@
+export * from "./useFileActions";

--- a/spa/src/hooks/file/useFileActions/useFileActions.test.ts
+++ b/spa/src/hooks/file/useFileActions/useFileActions.test.ts
@@ -1,0 +1,343 @@
+import { useFiles } from "@/contexts/files";
+import type { File } from "@/types";
+import { renderHook, waitFor } from "@testing-library/react";
+import { useNavigate } from "react-router-dom";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useFileActions } from ".";
+
+// Mock dependencies
+vi.mock("@/contexts/files", () => ({
+  useFiles: vi.fn(),
+}));
+
+vi.mock("react-router-dom", () => ({
+  useNavigate: vi.fn(),
+}));
+
+// Helper to create a mock file
+function createMockFile(overrides?: Partial<File>): File {
+  return {
+    object_name: "test-file.txt",
+    collection: "test-collection",
+    owner: "test@example.com",
+    original_filename: "test-file.txt",
+    upload_time: "2024-01-01T00:00:00Z",
+    content_type: "text/plain",
+    size: 1024,
+    ...overrides,
+  };
+}
+
+describe("useFileActions", () => {
+  const mockNavigate = vi.fn();
+  const mockDownloadFile = vi.fn();
+  const mockDeleteFile = vi.fn();
+  const mockArchiveFile = vi.fn();
+  const mockRefetchFiles = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    vi.mocked(useNavigate).mockReturnValue(mockNavigate);
+    vi.mocked(useFiles).mockReturnValue({
+      downloadFile: mockDownloadFile,
+      deleteFile: mockDeleteFile,
+      archiveFile: mockArchiveFile,
+      files: [],
+      loading: false,
+      error: null,
+      fetchFiles: vi.fn(),
+      fetchRecentFiles: vi.fn(),
+      uploadFile: vi.fn(),
+      downloadFiles: vi.fn(),
+      totalPages: 0,
+      currentPage: 1,
+      totalCount: 0,
+    });
+
+    mockRefetchFiles.mockResolvedValue(undefined);
+  });
+
+  describe("handleDownload", () => {
+    it("calls downloadFile with correct parameters", () => {
+      const { result } = renderHook(() => useFileActions(mockRefetchFiles));
+      const file = createMockFile();
+
+      result.current.handleDownload(file);
+
+      expect(mockDownloadFile).toHaveBeenCalledWith(
+        file.collection,
+        file.object_name,
+      );
+    });
+  });
+
+  describe("handleViewHistory", () => {
+    it("navigates to file detail page with encoded object name", () => {
+      const { result } = renderHook(() => useFileActions(mockRefetchFiles));
+      const file = createMockFile();
+
+      result.current.handleViewHistory(file);
+
+      expect(mockNavigate).toHaveBeenCalledWith(
+        `/collections/${file.collection}/files/${encodeURIComponent(file.object_name)}`,
+      );
+    });
+  });
+
+  describe("delete dialog", () => {
+    it("opens delete dialog when handleDelete is called", async () => {
+      const { result } = renderHook(() => useFileActions(mockRefetchFiles));
+      const file = createMockFile();
+
+      expect(result.current.deleteDialog.open).toBe(false);
+      expect(result.current.deleteDialog.file).toBeNull();
+
+      result.current.handleDelete(file);
+
+      await waitFor(() => {
+        expect(result.current.deleteDialog.open).toBe(true);
+        expect(result.current.deleteDialog.file).toBe(file);
+        expect(result.current.deleteDialog.isLoading).toBe(false);
+      });
+    });
+
+    it("closes delete dialog when onCancel is called", async () => {
+      const { result } = renderHook(() => useFileActions(mockRefetchFiles));
+      const file = createMockFile();
+
+      result.current.handleDelete(file);
+
+      await waitFor(() => {
+        expect(result.current.deleteDialog.open).toBe(true);
+      });
+
+      result.current.deleteDialog.onCancel();
+
+      await waitFor(() => {
+        expect(result.current.deleteDialog.open).toBe(false);
+        expect(result.current.deleteDialog.file).toBeNull();
+        expect(result.current.deleteDialog.isLoading).toBe(false);
+      });
+    });
+
+    it("successfully deletes file and refetches", async () => {
+      mockDeleteFile.mockResolvedValue(undefined);
+
+      const { result } = renderHook(() => useFileActions(mockRefetchFiles));
+      const file = createMockFile();
+
+      result.current.handleDelete(file);
+
+      await waitFor(() => {
+        expect(result.current.deleteDialog.open).toBe(true);
+      });
+
+      result.current.deleteDialog.onConfirm();
+
+      await waitFor(() => {
+        expect(mockDeleteFile).toHaveBeenCalledWith(
+          file.collection,
+          file.object_name,
+        );
+        expect(mockRefetchFiles).toHaveBeenCalled();
+        expect(result.current.deleteDialog.open).toBe(false);
+        expect(result.current.deleteDialog.file).toBeNull();
+        expect(result.current.deleteDialog.isLoading).toBe(false);
+      });
+    });
+
+    it("sets loading state during deletion", async () => {
+      let resolveDelete: () => void;
+      const deletePromise = new Promise<void>((resolve) => {
+        resolveDelete = resolve;
+      });
+      mockDeleteFile.mockReturnValue(deletePromise);
+
+      const { result } = renderHook(() => useFileActions(mockRefetchFiles));
+      const file = createMockFile();
+
+      result.current.handleDelete(file);
+
+      await waitFor(() => {
+        expect(result.current.deleteDialog.open).toBe(true);
+      });
+
+      result.current.deleteDialog.onConfirm();
+
+      await waitFor(() => {
+        expect(result.current.deleteDialog.isLoading).toBe(true);
+      });
+
+      resolveDelete!();
+      await deletePromise;
+
+      await waitFor(() => {
+        expect(result.current.deleteDialog.isLoading).toBe(false);
+      });
+    });
+
+    it("closes dialog on deletion error", async () => {
+      mockDeleteFile.mockRejectedValue(new Error("Delete failed"));
+
+      const { result } = renderHook(() => useFileActions(mockRefetchFiles));
+      const file = createMockFile();
+
+      result.current.handleDelete(file);
+
+      await waitFor(() => {
+        expect(result.current.deleteDialog.open).toBe(true);
+      });
+
+      result.current.deleteDialog.onConfirm();
+
+      await waitFor(() => {
+        expect(mockDeleteFile).toHaveBeenCalled();
+        expect(result.current.deleteDialog.open).toBe(false);
+        expect(result.current.deleteDialog.file).toBeNull();
+        expect(result.current.deleteDialog.isLoading).toBe(false);
+      });
+    });
+  });
+
+  describe("archive dialog", () => {
+    it("opens archive dialog when handleArchive is called", async () => {
+      const { result } = renderHook(() => useFileActions(mockRefetchFiles));
+      const file = createMockFile();
+
+      expect(result.current.archiveDialog.open).toBe(false);
+      expect(result.current.archiveDialog.file).toBeNull();
+
+      result.current.handleArchive(file);
+
+      await waitFor(() => {
+        expect(result.current.archiveDialog.open).toBe(true);
+        expect(result.current.archiveDialog.file).toBe(file);
+        expect(result.current.archiveDialog.isLoading).toBe(false);
+      });
+    });
+
+    it("closes archive dialog when onCancel is called", async () => {
+      const { result } = renderHook(() => useFileActions(mockRefetchFiles));
+      const file = createMockFile();
+
+      result.current.handleArchive(file);
+
+      await waitFor(() => {
+        expect(result.current.archiveDialog.open).toBe(true);
+      });
+
+      result.current.archiveDialog.onCancel();
+
+      await waitFor(() => {
+        expect(result.current.archiveDialog.open).toBe(false);
+        expect(result.current.archiveDialog.file).toBeNull();
+        expect(result.current.archiveDialog.isLoading).toBe(false);
+      });
+    });
+
+    it("successfully archives file and refetches", async () => {
+      mockArchiveFile.mockResolvedValue(undefined);
+
+      const { result } = renderHook(() => useFileActions(mockRefetchFiles));
+      const file = createMockFile();
+
+      result.current.handleArchive(file);
+
+      await waitFor(() => {
+        expect(result.current.archiveDialog.open).toBe(true);
+      });
+
+      result.current.archiveDialog.onConfirm();
+
+      await waitFor(() => {
+        expect(mockArchiveFile).toHaveBeenCalledWith(
+          file.collection,
+          file.object_name,
+        );
+        expect(mockRefetchFiles).toHaveBeenCalled();
+        expect(result.current.archiveDialog.open).toBe(false);
+        expect(result.current.archiveDialog.file).toBeNull();
+        expect(result.current.archiveDialog.isLoading).toBe(false);
+      });
+    });
+
+    it("sets loading state during archival", async () => {
+      let resolveArchive: () => void;
+      const archivePromise = new Promise<void>((resolve) => {
+        resolveArchive = resolve;
+      });
+      mockArchiveFile.mockReturnValue(archivePromise);
+
+      const { result } = renderHook(() => useFileActions(mockRefetchFiles));
+      const file = createMockFile();
+
+      result.current.handleArchive(file);
+
+      await waitFor(() => {
+        expect(result.current.archiveDialog.open).toBe(true);
+      });
+
+      result.current.archiveDialog.onConfirm();
+
+      await waitFor(() => {
+        expect(result.current.archiveDialog.isLoading).toBe(true);
+      });
+
+      resolveArchive!();
+      await archivePromise;
+
+      await waitFor(() => {
+        expect(result.current.archiveDialog.isLoading).toBe(false);
+      });
+    });
+
+    it("closes dialog on archive error", async () => {
+      mockArchiveFile.mockRejectedValue(new Error("Archive failed"));
+
+      const { result } = renderHook(() => useFileActions(mockRefetchFiles));
+      const file = createMockFile();
+
+      result.current.handleArchive(file);
+
+      await waitFor(() => {
+        expect(result.current.archiveDialog.open).toBe(true);
+      });
+
+      result.current.archiveDialog.onConfirm();
+
+      await waitFor(() => {
+        expect(mockArchiveFile).toHaveBeenCalled();
+        expect(result.current.archiveDialog.open).toBe(false);
+        expect(result.current.archiveDialog.file).toBeNull();
+        expect(result.current.archiveDialog.isLoading).toBe(false);
+      });
+    });
+  });
+
+  describe("multiple dialogs", () => {
+    it("maintains separate state for each dialog", async () => {
+      const { result } = renderHook(() => useFileActions(mockRefetchFiles));
+      const file1 = createMockFile({ object_name: "file1.txt" });
+      const file2 = createMockFile({ object_name: "file2.txt" });
+
+      result.current.handleDelete(file1);
+
+      await waitFor(() => {
+        expect(result.current.deleteDialog.open).toBe(true);
+        expect(result.current.deleteDialog.file).toBe(file1);
+        expect(result.current.archiveDialog.open).toBe(false);
+        expect(result.current.archiveDialog.file).toBeNull();
+      });
+
+      result.current.handleArchive(file2);
+
+      await waitFor(() => {
+        expect(result.current.archiveDialog.open).toBe(true);
+        expect(result.current.archiveDialog.file).toBe(file2);
+        expect(result.current.deleteDialog.open).toBe(true);
+        expect(result.current.deleteDialog.file).toBe(file1);
+      });
+    });
+  });
+});

--- a/spa/src/hooks/file/useFileActions/useFileActions.ts
+++ b/spa/src/hooks/file/useFileActions/useFileActions.ts
@@ -1,0 +1,149 @@
+import { useFiles } from "@/contexts/files";
+import type { File } from "@/types";
+import { useCallback, useState } from "react";
+import { useNavigate } from "react-router-dom";
+
+export interface FileActionsDialogState {
+  deleteDialog: {
+    open: boolean;
+    file: File | null;
+    isLoading: boolean;
+  };
+  archiveDialog: {
+    open: boolean;
+    file: File | null;
+    isLoading: boolean;
+  };
+}
+
+export function useFileActions(refetchFiles: () => void) {
+  const navigate = useNavigate();
+  const { downloadFile, deleteFile, archiveFile } = useFiles();
+
+  const [dialogState, setDialogState] = useState<FileActionsDialogState>({
+    deleteDialog: { open: false, file: null, isLoading: false },
+    archiveDialog: { open: false, file: null, isLoading: false },
+  });
+
+  // Download handler
+  const handleDownload = useCallback(
+    (file: File) => {
+      downloadFile(file.collection, file.object_name);
+    },
+    [downloadFile],
+  );
+
+  // View history handler - navigates to file detail page
+  const handleViewHistory = useCallback(
+    (file: File) => {
+      // Encode the object_name since it may contain slashes
+      const encodedObjectName = encodeURIComponent(file.object_name);
+      navigate(`/collections/${file.collection}/files/${encodedObjectName}`);
+    },
+    [navigate],
+  );
+
+  // Delete handlers
+  const handleDeleteClick = useCallback((file: File) => {
+    setDialogState((prev) => ({
+      ...prev,
+      deleteDialog: { open: true, file, isLoading: false },
+    }));
+  }, []);
+
+  const handleDeleteConfirm = useCallback(
+    async (file: File) => {
+      // Set loading state
+      setDialogState((prev) => ({
+        ...prev,
+        deleteDialog: { ...prev.deleteDialog, isLoading: true },
+      }));
+
+      try {
+        await deleteFile(file.collection, file.object_name);
+        setDialogState((prev) => ({
+          ...prev,
+          deleteDialog: { open: false, file: null, isLoading: false },
+        }));
+        refetchFiles();
+      } catch {
+        // Error is already handled by FilesContext with toast
+        // Close dialog even on error
+        setDialogState((prev) => ({
+          ...prev,
+          deleteDialog: { open: false, file: null, isLoading: false },
+        }));
+      }
+    },
+    [deleteFile, refetchFiles],
+  );
+
+  const handleDeleteCancel = useCallback(() => {
+    setDialogState((prev) => ({
+      ...prev,
+      deleteDialog: { open: false, file: null, isLoading: false },
+    }));
+  }, []);
+
+  // Archive handlers
+  const handleArchiveClick = useCallback((file: File) => {
+    setDialogState((prev) => ({
+      ...prev,
+      archiveDialog: { open: true, file, isLoading: false },
+    }));
+  }, []);
+
+  const handleArchiveConfirm = useCallback(
+    async (file: File) => {
+      // Set loading state
+      setDialogState((prev) => ({
+        ...prev,
+        archiveDialog: { ...prev.archiveDialog, isLoading: true },
+      }));
+
+      try {
+        await archiveFile(file.collection, file.object_name);
+        setDialogState((prev) => ({
+          ...prev,
+          archiveDialog: { open: false, file: null, isLoading: false },
+        }));
+        refetchFiles();
+      } catch {
+        // Error is already handled by FilesContext with toast
+        // Close dialog even on error
+        setDialogState((prev) => ({
+          ...prev,
+          archiveDialog: { open: false, file: null, isLoading: false },
+        }));
+      }
+    },
+    [archiveFile, refetchFiles],
+  );
+
+  const handleArchiveCancel = useCallback(() => {
+    setDialogState((prev) => ({
+      ...prev,
+      archiveDialog: { open: false, file: null, isLoading: false },
+    }));
+  }, []);
+
+  return {
+    // Action handlers to pass to tables
+    handleDownload,
+    handleViewHistory,
+    handleDelete: handleDeleteClick,
+    handleArchive: handleArchiveClick,
+
+    // Dialog state and handlers
+    deleteDialog: {
+      ...dialogState.deleteDialog,
+      onConfirm: () => handleDeleteConfirm(dialogState.deleteDialog.file!),
+      onCancel: handleDeleteCancel,
+    },
+    archiveDialog: {
+      ...dialogState.archiveDialog,
+      onConfirm: () => handleArchiveConfirm(dialogState.archiveDialog.file!),
+      onCancel: handleArchiveCancel,
+    },
+  };
+}

--- a/spa/src/hooks/file/useFilePermissions/index.ts
+++ b/spa/src/hooks/file/useFilePermissions/index.ts
@@ -1,0 +1,1 @@
+export * from "./useFilePermissions";

--- a/spa/src/hooks/file/useFilePermissions/useFilePermissions.test.ts
+++ b/spa/src/hooks/file/useFilePermissions/useFilePermissions.test.ts
@@ -1,0 +1,473 @@
+import type { File } from "@/types";
+import { renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useUser } from "../../user/useUser";
+import { useFilePermissions } from "./useFilePermissions";
+
+// Mock dependencies
+vi.mock("../../user/useUser", () => ({
+  useUser: vi.fn(),
+}));
+
+// Helper to create a mock file
+function createMockFile(overrides?: Partial<File>): File {
+  return {
+    object_name: "test-file.txt",
+    collection: "test-collection",
+    owner: "testuser",
+    original_filename: "test-file.txt",
+    upload_time: "2024-01-01T00:00:00Z",
+    content_type: "text/plain",
+    size: 1024,
+    ...overrides,
+  };
+}
+
+describe("useFilePermissions", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("when user is not authenticated", () => {
+    it("returns all permissions as false when user is null", () => {
+      vi.mocked(useUser).mockReturnValue(null);
+      const file = createMockFile();
+
+      const { result } = renderHook(() => useFilePermissions(file));
+
+      expect(result.current).toEqual({
+        canRead: false,
+        canWrite: false,
+        canDelete: false,
+        canDownload: false,
+        canArchive: false,
+        canViewHistory: false,
+        isOwnFile: false,
+      });
+    });
+  });
+
+  describe("when user has delete permission", () => {
+    it("grants full access for own file", () => {
+      vi.mocked(useUser).mockReturnValue({
+        username: "testuser",
+        name: "Test User",
+        email: "test@example.com",
+        roles: [],
+        collections: {
+          "test-collection": ["delete"],
+        },
+      });
+      const file = createMockFile({ owner: "testuser" });
+
+      const { result } = renderHook(() => useFilePermissions(file));
+
+      expect(result.current).toEqual({
+        canRead: true,
+        canWrite: true,
+        canDelete: true,
+        canDownload: true,
+        canArchive: true,
+        canViewHistory: true,
+        isOwnFile: true,
+      });
+    });
+
+    it("grants full access for other user's file", () => {
+      vi.mocked(useUser).mockReturnValue({
+        username: "testuser",
+        name: "Test User",
+        email: "test@example.com",
+        roles: [],
+        collections: {
+          "test-collection": ["delete"],
+        },
+      });
+      const file = createMockFile({ owner: "otheruser" });
+
+      const { result } = renderHook(() => useFilePermissions(file));
+
+      expect(result.current).toEqual({
+        canRead: true,
+        canWrite: true,
+        canDelete: true,
+        canDownload: true,
+        canArchive: true,
+        canViewHistory: true,
+        isOwnFile: false,
+      });
+    });
+
+    it("grants full access when user has multiple permissions including delete", () => {
+      vi.mocked(useUser).mockReturnValue({
+        username: "testuser",
+        name: "Test User",
+        email: "test@example.com",
+        roles: [],
+        collections: {
+          "test-collection": ["read", "write", "delete"],
+        },
+      });
+      const file = createMockFile({ owner: "testuser" });
+
+      const { result } = renderHook(() => useFilePermissions(file));
+
+      expect(result.current).toEqual({
+        canRead: true,
+        canWrite: true,
+        canDelete: true,
+        canDownload: true,
+        canArchive: true,
+        canViewHistory: true,
+        isOwnFile: true,
+      });
+    });
+  });
+
+  describe("when user has write permission", () => {
+    it("allows download for own file", () => {
+      vi.mocked(useUser).mockReturnValue({
+        username: "testuser",
+        name: "Test User",
+        email: "test@example.com",
+        roles: [],
+        collections: {
+          "test-collection": ["write"],
+        },
+      });
+      const file = createMockFile({ owner: "testuser" });
+
+      const { result } = renderHook(() => useFilePermissions(file));
+
+      expect(result.current).toEqual({
+        canRead: true,
+        canWrite: true,
+        canDelete: false,
+        canDownload: true,
+        canArchive: false,
+        canViewHistory: false,
+        isOwnFile: true,
+      });
+    });
+
+    it("does not allow download for other user's file", () => {
+      vi.mocked(useUser).mockReturnValue({
+        username: "testuser",
+        name: "Test User",
+        email: "test@example.com",
+        roles: [],
+        collections: {
+          "test-collection": ["write"],
+        },
+      });
+      const file = createMockFile({ owner: "otheruser" });
+
+      const { result } = renderHook(() => useFilePermissions(file));
+
+      expect(result.current).toEqual({
+        canRead: true,
+        canWrite: true,
+        canDelete: false,
+        canDownload: false,
+        canArchive: false,
+        canViewHistory: false,
+        isOwnFile: false,
+      });
+    });
+
+    it("allows download when user has read and write permissions for own file", () => {
+      vi.mocked(useUser).mockReturnValue({
+        username: "testuser",
+        name: "Test User",
+        email: "test@example.com",
+        roles: [],
+        collections: {
+          "test-collection": ["read", "write"],
+        },
+      });
+      const file = createMockFile({ owner: "testuser" });
+
+      const { result } = renderHook(() => useFilePermissions(file));
+
+      expect(result.current).toEqual({
+        canRead: true,
+        canWrite: true,
+        canDelete: false,
+        canDownload: true,
+        canArchive: false,
+        canViewHistory: false,
+        isOwnFile: true,
+      });
+    });
+  });
+
+  describe("when user has read permission", () => {
+    it("allows download for own file", () => {
+      vi.mocked(useUser).mockReturnValue({
+        username: "testuser",
+        name: "Test User",
+        email: "test@example.com",
+        roles: [],
+        collections: {
+          "test-collection": ["read"],
+        },
+      });
+      const file = createMockFile({ owner: "testuser" });
+
+      const { result } = renderHook(() => useFilePermissions(file));
+
+      expect(result.current).toEqual({
+        canRead: true,
+        canWrite: false,
+        canDelete: false,
+        canDownload: true,
+        canArchive: false,
+        canViewHistory: false,
+        isOwnFile: true,
+      });
+    });
+
+    it("allows download for other user's file", () => {
+      vi.mocked(useUser).mockReturnValue({
+        username: "testuser",
+        name: "Test User",
+        email: "test@example.com",
+        roles: [],
+        collections: {
+          "test-collection": ["read"],
+        },
+      });
+      const file = createMockFile({ owner: "otheruser" });
+
+      const { result } = renderHook(() => useFilePermissions(file));
+
+      expect(result.current).toEqual({
+        canRead: true,
+        canWrite: false,
+        canDelete: false,
+        canDownload: true,
+        canArchive: false,
+        canViewHistory: false,
+        isOwnFile: false,
+      });
+    });
+
+    it("does not grant write or delete permissions", () => {
+      vi.mocked(useUser).mockReturnValue({
+        username: "testuser",
+        name: "Test User",
+        email: "test@example.com",
+        roles: [],
+        collections: {
+          "test-collection": ["read"],
+        },
+      });
+      const file = createMockFile();
+
+      const { result } = renderHook(() => useFilePermissions(file));
+
+      expect(result.current.canWrite).toBe(false);
+      expect(result.current.canDelete).toBe(false);
+      expect(result.current.canArchive).toBe(false);
+      expect(result.current.canViewHistory).toBe(false);
+    });
+  });
+
+  describe("isOwnFile calculation", () => {
+    it("correctly identifies own file", () => {
+      vi.mocked(useUser).mockReturnValue({
+        username: "testuser",
+        name: "Test User",
+        email: "test@example.com",
+        roles: [],
+        collections: {
+          "test-collection": ["read"],
+        },
+      });
+      const file = createMockFile({ owner: "testuser" });
+
+      const { result } = renderHook(() => useFilePermissions(file));
+
+      expect(result.current.isOwnFile).toBe(true);
+    });
+
+    it("correctly identifies other user's file", () => {
+      vi.mocked(useUser).mockReturnValue({
+        username: "testuser",
+        name: "Test User",
+        email: "test@example.com",
+        roles: [],
+        collections: {
+          "test-collection": ["read"],
+        },
+      });
+      const file = createMockFile({ owner: "otheruser" });
+
+      const { result } = renderHook(() => useFilePermissions(file));
+
+      expect(result.current.isOwnFile).toBe(false);
+    });
+
+    it("handles case-sensitive owner comparison", () => {
+      vi.mocked(useUser).mockReturnValue({
+        username: "TestUser",
+        name: "Test User",
+        email: "test@example.com",
+        roles: [],
+        collections: {
+          "test-collection": ["read"],
+        },
+      });
+      const file = createMockFile({ owner: "testuser" });
+
+      const { result } = renderHook(() => useFilePermissions(file));
+
+      expect(result.current.isOwnFile).toBe(false);
+    });
+  });
+
+  describe("permission precedence", () => {
+    it("prioritizes delete permission over write", () => {
+      vi.mocked(useUser).mockReturnValue({
+        username: "testuser",
+        name: "Test User",
+        email: "test@example.com",
+        roles: [],
+        collections: {
+          "test-collection": ["write", "delete"],
+        },
+      });
+      const file = createMockFile({ owner: "otheruser" });
+
+      const { result } = renderHook(() => useFilePermissions(file));
+
+      // Should get full access due to delete permission
+      expect(result.current.canDownload).toBe(true);
+      expect(result.current.canArchive).toBe(true);
+      expect(result.current.canViewHistory).toBe(true);
+    });
+
+    it("prioritizes delete permission over read", () => {
+      vi.mocked(useUser).mockReturnValue({
+        username: "testuser",
+        name: "Test User",
+        email: "test@example.com",
+        roles: [],
+        collections: {
+          "test-collection": ["read", "delete"],
+        },
+      });
+      const file = createMockFile({ owner: "otheruser" });
+
+      const { result } = renderHook(() => useFilePermissions(file));
+
+      // Should get full access due to delete permission
+      expect(result.current.canWrite).toBe(true);
+      expect(result.current.canDelete).toBe(true);
+      expect(result.current.canArchive).toBe(true);
+      expect(result.current.canViewHistory).toBe(true);
+    });
+
+    it("prioritizes write permission over read for own files", () => {
+      vi.mocked(useUser).mockReturnValue({
+        username: "testuser",
+        name: "Test User",
+        email: "test@example.com",
+        roles: [],
+        collections: {
+          "test-collection": ["read", "write"],
+        },
+      });
+      const file = createMockFile({ owner: "testuser" });
+
+      const { result } = renderHook(() => useFilePermissions(file));
+
+      // Write permission is checked first, so should allow download for own file
+      expect(result.current.canDownload).toBe(true);
+      expect(result.current.canWrite).toBe(true);
+    });
+  });
+
+  describe("memoization behavior", () => {
+    it("returns same reference when dependencies don't change", () => {
+      vi.mocked(useUser).mockReturnValue({
+        username: "testuser",
+        name: "Test User",
+        email: "test@example.com",
+        roles: [],
+        collections: {
+          "test-collection": ["read"],
+        },
+      });
+      const file = createMockFile();
+
+      const { result, rerender } = renderHook(() => useFilePermissions(file));
+      const firstResult = result.current;
+
+      rerender();
+      const secondResult = result.current;
+
+      expect(firstResult).toBe(secondResult);
+    });
+
+    it("returns new reference when user changes", () => {
+      const user1 = {
+        username: "testuser1",
+        name: "Test User 1",
+        email: "test1@example.com",
+        roles: [],
+        collections: {
+          "test-collection": ["read"],
+        },
+      };
+
+      const user2 = {
+        username: "testuser2",
+        name: "Test User 2",
+        email: "test2@example.com",
+        roles: [],
+        collections: {
+          "test-collection": ["write"],
+        },
+      };
+
+      vi.mocked(useUser).mockReturnValue(user1);
+      const file = createMockFile();
+
+      const { result, rerender } = renderHook(() => useFilePermissions(file));
+      const firstResult = result.current;
+
+      vi.mocked(useUser).mockReturnValue(user2);
+      rerender();
+      const secondResult = result.current;
+
+      expect(firstResult).not.toBe(secondResult);
+    });
+
+    it("returns new reference when file changes", () => {
+      vi.mocked(useUser).mockReturnValue({
+        username: "testuser",
+        name: "Test User",
+        email: "test@example.com",
+        roles: [],
+        collections: {
+          "test-collection": ["read"],
+        },
+      });
+
+      const file1 = createMockFile({ object_name: "file1.txt" });
+      const file2 = createMockFile({ object_name: "file2.txt" });
+
+      const { result, rerender } = renderHook(
+        ({ file }) => useFilePermissions(file),
+        { initialProps: { file: file1 } },
+      );
+      const firstResult = result.current;
+
+      rerender({ file: file2 });
+      const secondResult = result.current;
+
+      expect(firstResult).not.toBe(secondResult);
+    });
+  });
+});

--- a/spa/src/hooks/file/useFilePermissions/useFilePermissions.ts
+++ b/spa/src/hooks/file/useFilePermissions/useFilePermissions.ts
@@ -1,0 +1,97 @@
+import type { File } from "@/types";
+import { useMemo } from "react";
+import { useUser } from "../../user/useUser";
+
+interface FilePermissions {
+  canRead: boolean;
+  canWrite: boolean;
+  canDelete: boolean;
+  canDownload: boolean;
+  canArchive: boolean;
+  canViewHistory: boolean;
+  isOwnFile: boolean;
+}
+
+/**
+ * Hook to determine user permissions for a file based on collection permissions
+ *
+ * Permission model:
+ * - delete permission: Full access (download, view history, archive, delete)
+ * - write permission: Can download own files
+ * - read permission: Can download any file
+ */
+export function useFilePermissions(file: File): FilePermissions {
+  const user = useUser();
+
+  return useMemo(() => {
+    if (!user) {
+      return {
+        canRead: false,
+        canWrite: false,
+        canDelete: false,
+        canDownload: false,
+        canArchive: false,
+        canViewHistory: false,
+        isOwnFile: false,
+      };
+    }
+
+    const isOwnFile = file.owner === user.username;
+
+    // Get collection permissions
+    const collectionPermissions = user.collections?.[file.collection] || [];
+    const hasDeletePermission = collectionPermissions.includes("delete");
+    const hasWritePermission = collectionPermissions.includes("write");
+    const hasReadPermission = collectionPermissions.includes("read");
+
+    // Users with delete permission have full access
+    if (hasDeletePermission) {
+      return {
+        canRead: true,
+        canWrite: true,
+        canDelete: true,
+        canDownload: true,
+        canArchive: true,
+        canViewHistory: true,
+        isOwnFile,
+      };
+    }
+
+    // Users with write permission can download their own files
+    if (hasWritePermission) {
+      return {
+        canRead: true,
+        canWrite: true,
+        canDelete: false,
+        canDownload: isOwnFile,
+        canArchive: false,
+        canViewHistory: false,
+        isOwnFile,
+      };
+    }
+
+    // Users with read permission can download any file
+    if (hasReadPermission) {
+      return {
+        canRead: true,
+        canWrite: false,
+        canDelete: false,
+        canDownload: true,
+        canArchive: false,
+        canViewHistory: false,
+        isOwnFile,
+      };
+    }
+
+    // No permissions
+    return {
+      canRead: false,
+      canWrite: false,
+      canDelete: false,
+      canDownload: false,
+      canArchive: false,
+      canViewHistory: false,
+      isOwnFile,
+    };
+  }, [user, file]);
+}

--- a/spa/src/hooks/file/useFilesSort/index.ts
+++ b/spa/src/hooks/file/useFilesSort/index.ts
@@ -1,0 +1,1 @@
+export * from "./useFilesSort";

--- a/spa/src/hooks/file/useFilesSort/useFilesSort.test.ts
+++ b/spa/src/hooks/file/useFilesSort/useFilesSort.test.ts
@@ -1,0 +1,436 @@
+import type { File } from "@/types";
+import { act, renderHook } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { useFilesSort } from "./useFilesSort";
+
+// Helper to create a mock file
+function createMockFile(overrides?: Partial<File>): File {
+  return {
+    object_name: "test-file.txt",
+    collection: "test-collection",
+    owner: "test@example.com",
+    original_filename: "test-file.txt",
+    upload_time: "2024-01-01T00:00:00Z",
+    content_type: "text/plain",
+    size: 1024,
+    ...overrides,
+  };
+}
+
+describe("useFilesSort", () => {
+  describe("initialization", () => {
+    it("initializes with default options", () => {
+      const files = [createMockFile()];
+      const { result } = renderHook(() => useFilesSort(files));
+
+      expect(result.current.sortBy).toBe("status");
+      expect(result.current.sortDirection).toBe("desc");
+      expect(result.current.sortedFiles).toEqual(files);
+    });
+
+    it("initializes with custom options", () => {
+      const files = [createMockFile()];
+      const { result } = renderHook(() =>
+        useFilesSort(files, {
+          initialSortBy: "date",
+          initialDirection: "asc",
+        }),
+      );
+
+      expect(result.current.sortBy).toBe("date");
+      expect(result.current.sortDirection).toBe("asc");
+    });
+
+    it("handles empty files array", () => {
+      const { result } = renderHook(() => useFilesSort([]));
+
+      expect(result.current.sortedFiles).toEqual([]);
+    });
+  });
+
+  describe("sorting by status", () => {
+    it("sorts files by status in descending order", () => {
+      const files = [
+        createMockFile({
+          object_name: "file1",
+          metadata: { status: "Done" },
+        }),
+        createMockFile({
+          object_name: "file2",
+          metadata: { status: "In progress" },
+        }),
+        createMockFile({
+          object_name: "file3",
+          metadata: { status: "Review" },
+        }),
+      ];
+
+      const { result } = renderHook(() =>
+        useFilesSort(files, {
+          initialSortBy: "status",
+          initialDirection: "desc",
+        }),
+      );
+
+      expect(result.current.sortedFiles[0].metadata?.status).toBe("Review");
+      expect(result.current.sortedFiles[1].metadata?.status).toBe(
+        "In progress",
+      );
+      expect(result.current.sortedFiles[2].metadata?.status).toBe("Done");
+    });
+
+    it("sorts files by status in ascending order", () => {
+      const files = [
+        createMockFile({
+          object_name: "file1",
+          metadata: { status: "Done" },
+        }),
+        createMockFile({
+          object_name: "file2",
+          metadata: { status: "Review" },
+        }),
+        createMockFile({
+          object_name: "file3",
+          metadata: { status: "In progress" },
+        }),
+      ];
+
+      const { result } = renderHook(() =>
+        useFilesSort(files, {
+          initialSortBy: "status",
+          initialDirection: "asc",
+        }),
+      );
+
+      expect(result.current.sortedFiles[0].metadata?.status).toBe("Done");
+      expect(result.current.sortedFiles[1].metadata?.status).toBe(
+        "In progress",
+      );
+      expect(result.current.sortedFiles[2].metadata?.status).toBe("Review");
+    });
+
+    it("handles files with missing status", () => {
+      const files = [
+        createMockFile({
+          object_name: "file1",
+          metadata: { status: "Done" },
+        }),
+        createMockFile({
+          object_name: "file2",
+          metadata: undefined,
+        }),
+        createMockFile({
+          object_name: "file3",
+          metadata: { status: "Review" },
+        }),
+      ];
+
+      const { result } = renderHook(() =>
+        useFilesSort(files, {
+          initialSortBy: "status",
+          initialDirection: "asc",
+        }),
+      );
+
+      // File without status should get default "In progress"
+      expect(result.current.sortedFiles).toHaveLength(3);
+      expect(result.current.sortedFiles[0].metadata?.status).toBe("Done");
+      expect(result.current.sortedFiles[2].metadata?.status).toBe("Review");
+    });
+  });
+
+  describe("sorting by uploader", () => {
+    it("sorts files by uploader in ascending order", () => {
+      const files = [
+        createMockFile({ object_name: "file1", owner: "charlie@example.com" }),
+        createMockFile({ object_name: "file2", owner: "alice@example.com" }),
+        createMockFile({ object_name: "file3", owner: "bob@example.com" }),
+      ];
+
+      const { result } = renderHook(() =>
+        useFilesSort(files, {
+          initialSortBy: "uploader",
+          initialDirection: "asc",
+        }),
+      );
+
+      expect(result.current.sortedFiles[0].owner).toBe("alice@example.com");
+      expect(result.current.sortedFiles[1].owner).toBe("bob@example.com");
+      expect(result.current.sortedFiles[2].owner).toBe("charlie@example.com");
+    });
+
+    it("sorts files by uploader in descending order", () => {
+      const files = [
+        createMockFile({ object_name: "file1", owner: "alice@example.com" }),
+        createMockFile({ object_name: "file2", owner: "charlie@example.com" }),
+        createMockFile({ object_name: "file3", owner: "bob@example.com" }),
+      ];
+
+      const { result } = renderHook(() =>
+        useFilesSort(files, {
+          initialSortBy: "uploader",
+          initialDirection: "desc",
+        }),
+      );
+
+      expect(result.current.sortedFiles[0].owner).toBe("charlie@example.com");
+      expect(result.current.sortedFiles[1].owner).toBe("bob@example.com");
+      expect(result.current.sortedFiles[2].owner).toBe("alice@example.com");
+    });
+
+    it("handles case-insensitive sorting", () => {
+      const files = [
+        createMockFile({ object_name: "file1", owner: "CHARLIE@example.com" }),
+        createMockFile({ object_name: "file2", owner: "alice@example.com" }),
+        createMockFile({ object_name: "file3", owner: "Bob@example.com" }),
+      ];
+
+      const { result } = renderHook(() =>
+        useFilesSort(files, {
+          initialSortBy: "uploader",
+          initialDirection: "asc",
+        }),
+      );
+
+      expect(result.current.sortedFiles[0].owner).toBe("alice@example.com");
+      expect(result.current.sortedFiles[1].owner).toBe("Bob@example.com");
+      expect(result.current.sortedFiles[2].owner).toBe("CHARLIE@example.com");
+    });
+
+    it("handles files with null/undefined owner", () => {
+      const files = [
+        createMockFile({ object_name: "file1", owner: "bob@example.com" }),
+        createMockFile({ object_name: "file2", owner: undefined as any }),
+        createMockFile({ object_name: "file3", owner: "alice@example.com" }),
+      ];
+
+      const { result } = renderHook(() =>
+        useFilesSort(files, {
+          initialSortBy: "uploader",
+          initialDirection: "asc",
+        }),
+      );
+
+      expect(result.current.sortedFiles).toHaveLength(3);
+    });
+  });
+
+  describe("sorting by date", () => {
+    it("sorts files by date in ascending order", () => {
+      const files = [
+        createMockFile({
+          object_name: "file1",
+          upload_time: "2024-03-01T00:00:00Z",
+        }),
+        createMockFile({
+          object_name: "file2",
+          upload_time: "2024-01-01T00:00:00Z",
+        }),
+        createMockFile({
+          object_name: "file3",
+          upload_time: "2024-02-01T00:00:00Z",
+        }),
+      ];
+
+      const { result } = renderHook(() =>
+        useFilesSort(files, { initialSortBy: "date", initialDirection: "asc" }),
+      );
+
+      expect(result.current.sortedFiles[0].upload_time).toBe(
+        "2024-01-01T00:00:00Z",
+      );
+      expect(result.current.sortedFiles[1].upload_time).toBe(
+        "2024-02-01T00:00:00Z",
+      );
+      expect(result.current.sortedFiles[2].upload_time).toBe(
+        "2024-03-01T00:00:00Z",
+      );
+    });
+
+    it("sorts files by date in descending order", () => {
+      const files = [
+        createMockFile({
+          object_name: "file1",
+          upload_time: "2024-01-01T00:00:00Z",
+        }),
+        createMockFile({
+          object_name: "file2",
+          upload_time: "2024-03-01T00:00:00Z",
+        }),
+        createMockFile({
+          object_name: "file3",
+          upload_time: "2024-02-01T00:00:00Z",
+        }),
+      ];
+
+      const { result } = renderHook(() =>
+        useFilesSort(files, {
+          initialSortBy: "date",
+          initialDirection: "desc",
+        }),
+      );
+
+      expect(result.current.sortedFiles[0].upload_time).toBe(
+        "2024-03-01T00:00:00Z",
+      );
+      expect(result.current.sortedFiles[1].upload_time).toBe(
+        "2024-02-01T00:00:00Z",
+      );
+      expect(result.current.sortedFiles[2].upload_time).toBe(
+        "2024-01-01T00:00:00Z",
+      );
+    });
+
+    it("handles invalid dates by treating them as epoch", () => {
+      const files = [
+        createMockFile({
+          object_name: "file1",
+          upload_time: "2024-01-01T00:00:00Z",
+        }),
+        createMockFile({
+          object_name: "file2",
+          upload_time: "invalid-date" as any,
+        }),
+        createMockFile({
+          object_name: "file3",
+          upload_time: "2024-02-01T00:00:00Z",
+        }),
+      ];
+
+      const { result } = renderHook(() =>
+        useFilesSort(files, { initialSortBy: "date", initialDirection: "asc" }),
+      );
+
+      // Invalid date (treated as 0) should come first in ascending order
+      expect(result.current.sortedFiles[0].object_name).toBe("file2");
+      expect(result.current.sortedFiles[1].upload_time).toBe(
+        "2024-01-01T00:00:00Z",
+      );
+      expect(result.current.sortedFiles[2].upload_time).toBe(
+        "2024-02-01T00:00:00Z",
+      );
+    });
+  });
+
+  describe("handleSortChange", () => {
+    it("changes sort field and resets to descending", () => {
+      const files = [createMockFile()];
+      const { result } = renderHook(() =>
+        useFilesSort(files, {
+          initialSortBy: "status",
+          initialDirection: "asc",
+        }),
+      );
+
+      expect(result.current.sortBy).toBe("status");
+      expect(result.current.sortDirection).toBe("asc");
+
+      act(() => {
+        result.current.handleSortChange("date");
+      });
+
+      expect(result.current.sortBy).toBe("date");
+      expect(result.current.sortDirection).toBe("desc");
+    });
+
+    it("toggles sort direction when clicking same field", () => {
+      const files = [createMockFile()];
+      const { result } = renderHook(() =>
+        useFilesSort(files, {
+          initialSortBy: "status",
+          initialDirection: "desc",
+        }),
+      );
+
+      expect(result.current.sortDirection).toBe("desc");
+
+      act(() => {
+        result.current.handleSortChange("status");
+      });
+
+      expect(result.current.sortBy).toBe("status");
+      expect(result.current.sortDirection).toBe("asc");
+
+      act(() => {
+        result.current.handleSortChange("status");
+      });
+
+      expect(result.current.sortDirection).toBe("desc");
+    });
+  });
+
+  describe("setSortBy and setSortDirection", () => {
+    it("allows manual control of sortBy", () => {
+      const files = [createMockFile()];
+      const { result } = renderHook(() => useFilesSort(files));
+
+      expect(result.current.sortBy).toBe("status");
+
+      act(() => {
+        result.current.setSortBy("uploader");
+      });
+
+      expect(result.current.sortBy).toBe("uploader");
+    });
+
+    it("allows manual control of sortDirection", () => {
+      const files = [createMockFile()];
+      const { result } = renderHook(() => useFilesSort(files));
+
+      expect(result.current.sortDirection).toBe("desc");
+
+      act(() => {
+        result.current.setSortDirection("asc");
+      });
+
+      expect(result.current.sortDirection).toBe("asc");
+    });
+  });
+
+  describe("memoization", () => {
+    it("returns same sortedFiles reference when files and sort params unchanged", () => {
+      const files = [createMockFile()];
+      const { result, rerender } = renderHook(() => useFilesSort(files));
+
+      const firstResult = result.current.sortedFiles;
+
+      rerender();
+
+      expect(result.current.sortedFiles).toBe(firstResult);
+    });
+
+    it("returns new sortedFiles reference when files change", () => {
+      const files1 = [createMockFile({ object_name: "file1" })];
+      const files2 = [createMockFile({ object_name: "file2" })];
+
+      const { result, rerender } = renderHook(
+        ({ files }) => useFilesSort(files),
+        { initialProps: { files: files1 } },
+      );
+
+      const firstResult = result.current.sortedFiles;
+
+      rerender({ files: files2 });
+
+      expect(result.current.sortedFiles).not.toBe(firstResult);
+      expect(result.current.sortedFiles[0].object_name).toBe("file2");
+    });
+
+    it("returns new sortedFiles reference when sort params change", () => {
+      const files = [
+        createMockFile({ object_name: "file1", owner: "bob@example.com" }),
+        createMockFile({ object_name: "file2", owner: "alice@example.com" }),
+      ];
+
+      const { result } = renderHook(() => useFilesSort(files));
+
+      const firstResult = result.current.sortedFiles;
+
+      act(() => {
+        result.current.setSortBy("uploader");
+      });
+
+      expect(result.current.sortedFiles).not.toBe(firstResult);
+    });
+  });
+});

--- a/spa/src/hooks/file/useFilesSort/useFilesSort.ts
+++ b/spa/src/hooks/file/useFilesSort/useFilesSort.ts
@@ -1,0 +1,79 @@
+import type { File } from "@/types";
+import type { FileSortField, SortDirection } from "@/types/services/files";
+import { useMemo, useState } from "react";
+
+const DEFAULT_STATUS = "In progress";
+
+export const sortOptions = [
+  { value: "status", label: "Status" },
+  { value: "uploader", label: "Uploader" },
+  { value: "date", label: "Date" },
+];
+
+export interface UseFilesSortOptions {
+  initialSortBy?: FileSortField;
+  initialDirection?: SortDirection;
+}
+
+export function useFilesSort(files: File[], options: UseFilesSortOptions = {}) {
+  const { initialSortBy = "status", initialDirection = "desc" } = options;
+
+  const [sortBy, setSortBy] = useState<FileSortField>(initialSortBy);
+  const [sortDirection, setSortDirection] =
+    useState<SortDirection>(initialDirection);
+
+  const sortedFiles = useMemo(() => {
+    const sorted = [...files].sort((a, b) => {
+      let aValue: string | number;
+      let bValue: string | number;
+
+      switch (sortBy) {
+        case "status":
+          aValue = (a.metadata?.status ?? DEFAULT_STATUS).toLowerCase();
+          bValue = (b.metadata?.status ?? DEFAULT_STATUS).toLowerCase();
+          break;
+        case "uploader":
+          aValue = (a.owner ?? "").toLowerCase();
+          bValue = (b.owner ?? "").toLowerCase();
+          break;
+        case "date": {
+          const aDate = new Date(a.upload_time);
+          const bDate = new Date(b.upload_time);
+
+          // Handle invalid dates by treating them as earliest/latest
+          aValue = isNaN(aDate.getTime()) ? 0 : aDate.getTime();
+          bValue = isNaN(bDate.getTime()) ? 0 : bDate.getTime();
+          break;
+        }
+        default:
+          return 0;
+      }
+
+      if (aValue < bValue) return sortDirection === "asc" ? -1 : 1;
+      if (aValue > bValue) return sortDirection === "asc" ? 1 : -1;
+      return 0;
+    });
+
+    return sorted;
+  }, [files, sortBy, sortDirection]);
+
+  const handleSortChange = (field: FileSortField) => {
+    if (field === sortBy) {
+      // Toggle direction if same field
+      setSortDirection((prev) => (prev === "asc" ? "desc" : "asc"));
+    } else {
+      // Reset to descending for new field
+      setSortBy(field);
+      setSortDirection("desc");
+    }
+  };
+
+  return {
+    sortedFiles,
+    sortBy,
+    sortDirection,
+    setSortBy,
+    setSortDirection,
+    handleSortChange,
+  };
+}

--- a/spa/src/hooks/user/useUser.test.ts
+++ b/spa/src/hooks/user/useUser.test.ts
@@ -53,6 +53,7 @@ describe("useUser", () => {
       vi.mocked(useAuth).mockReturnValue(
         createMockAuth({
           profile: {
+            preferred_username: "johndoe",
             given_name: "John",
             family_name: "Doe",
             email: "john.doe@example.com",
@@ -67,6 +68,7 @@ describe("useUser", () => {
       const { result } = renderHook(() => useUser());
 
       expect(result.current).toEqual({
+        username: "johndoe",
         name: "John Doe",
         email: "john.doe@example.com",
         collections: {
@@ -91,6 +93,7 @@ describe("useUser", () => {
 
       const { result } = renderHook(() => useUser());
 
+      expect(result.current?.username).toBe("johndoe");
       expect(result.current?.name).toBe("johndoe");
     });
 
@@ -108,6 +111,7 @@ describe("useUser", () => {
 
       const { result } = renderHook(() => useUser());
 
+      expect(result.current?.username).toBe("johndoe");
       expect(result.current?.name).toBe("johndoe");
     });
 
@@ -124,6 +128,7 @@ describe("useUser", () => {
 
       const { result } = renderHook(() => useUser());
 
+      expect(result.current?.username).toBe("johndoe");
       expect(result.current?.name).toBe("johndoe");
     });
 
@@ -139,6 +144,7 @@ describe("useUser", () => {
 
       const { result } = renderHook(() => useUser());
 
+      expect(result.current?.username).toBe("");
       expect(result.current?.name).toBe("Unknown User");
     });
 

--- a/spa/src/hooks/user/useUser.ts
+++ b/spa/src/hooks/user/useUser.ts
@@ -15,11 +15,14 @@ export function useUser(): User | null {
     }
 
     const profile = auth.user.profile as Record<string, unknown>;
+    const username = (profile?.preferred_username as string) || "";
+
     return {
+      username, // Keycloak preferred_username - matches backend user.username
       name:
         profile?.given_name && profile?.family_name
           ? `${profile.given_name} ${profile.family_name}`
-          : (profile?.preferred_username as string) || "Unknown User",
+          : username || "Unknown User",
       email: (profile?.email as string) || "",
       collections: profile?.collections as Record<string, string[]>,
       roles: [], // Roles not currently used - permissions are collection-based

--- a/spa/src/pages/dashboard/Dashboard.stories.tsx
+++ b/spa/src/pages/dashboard/Dashboard.stories.tsx
@@ -1,0 +1,517 @@
+import { CollectionsProvider } from "@/contexts/collections/CollectionsContext";
+import { FilesProvider } from "@/contexts/files/FilesContext";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { delay, http, HttpResponse } from "msw";
+import React from "react";
+import { AuthContext, type AuthContextProps } from "react-oidc-context";
+import { MemoryRouter } from "react-router-dom";
+import { Dashboard } from "./Dashboard";
+
+const meta: Meta<typeof Dashboard> = {
+  title: "Pages/Dashboard",
+  component: Dashboard,
+  parameters: {
+    layout: "fullscreen",
+    design: {
+      type: "figma",
+      url: "https://www.figma.com/design/SQOopW8mFNB8TLQSZvOySp/RBTP-UI?node-id=9-2279&t=X1ojbU0VMwecFl97-4",
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof Dashboard>;
+
+// Mock user data - Admin
+const mockAdminUser = {
+  id: "admin-id",
+  username: "admin",
+  email: "admin@example.com",
+  name: "Admin User",
+  collections: {
+    test: ["read", "write", "delete"],
+    restricted: ["read", "write", "delete"],
+    shared: ["read", "write", "delete"],
+  },
+  realm_access: {
+    roles: ["admin"],
+  },
+};
+
+// Mock user data - Trust Architect
+const mockTAUser = {
+  id: "ta-id",
+  username: "trust-architect",
+  email: "ta@example.com",
+  name: "Trust Architect",
+  collections: {
+    test: ["read", "write", "delete"],
+    restricted: ["read", "write", "delete"],
+    shared: ["read", "write", "delete"],
+  },
+  realm_access: {
+    roles: ["trust-architect"],
+  },
+};
+
+// Mock user data - Participant
+const mockParticipantUser = {
+  id: "participant-id",
+  username: "participant",
+  email: "participant@example.com",
+  name: "Project Participant",
+  collections: {
+    test: ["read", "write"],
+    shared: ["read", "write"],
+  },
+  realm_access: {
+    roles: ["project-participant"],
+  },
+};
+
+// Mock Auth Context Provider
+function MockAuthProvider({
+  children,
+  user = mockAdminUser,
+}: {
+  children: React.ReactNode;
+  user?: {
+    id: string;
+    username: string;
+    email: string;
+    name: string;
+    collections: Record<string, string[]>;
+    realm_access: {
+      roles: string[];
+    };
+  };
+}) {
+  const mockAuthContext = {
+    user: {
+      profile: user,
+      access_token: "mock-token",
+      token_type: "Bearer",
+      expires_at: Date.now() + 3600000,
+    },
+    isAuthenticated: true,
+    isLoading: false,
+    error: undefined,
+    settings: {},
+    signinRedirect: async () => {},
+    signoutRedirect: async () => {},
+    signinSilent: async () => {},
+    removeUser: async () => {},
+    clearStaleState: async () => {},
+    querySessionStatus: async () => {},
+    revokeTokens: async () => {},
+    startSilentRenew: () => {},
+    stopSilentRenew: () => {},
+  };
+
+  return (
+    <AuthContext.Provider
+      value={mockAuthContext as unknown as AuthContextProps}
+    >
+      {children}
+    </AuthContext.Provider>
+  );
+}
+
+// Mock files data
+const mockFiles = [
+  {
+    object_name: "test/admin/document-1.pdf",
+    original_filename: "document-1.pdf",
+    content_type: "application/pdf",
+    size: 2456789,
+    upload_time: "2025-10-13T14:30:00Z",
+    owner: "admin@example.com",
+    collection: "test",
+    metadata: {
+      status: "Completed",
+      tags: ["important", "review"],
+    },
+  },
+  {
+    object_name: "shared/jane-smith/report-q3.xlsx",
+    original_filename: "report-q3.xlsx",
+    content_type:
+      "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+    size: 1234567,
+    upload_time: "2025-10-13T10:15:00Z",
+    owner: "jane-smith",
+    collection: "shared",
+    metadata: {
+      status: "In progress",
+      tags: ["quarterly", "finance"],
+    },
+  },
+  {
+    object_name: "test/participant/my-data.xlsx",
+    original_filename: "my-data.xlsx",
+    content_type:
+      "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+    size: 3456789,
+    upload_time: "2025-10-13T09:00:00Z",
+    owner: "participant@example.com",
+    collection: "test",
+    metadata: {
+      status: "In progress",
+      tags: ["data", "analysis"],
+    },
+  },
+  {
+    object_name: "test/john-doe/presentation.pptx",
+    original_filename: "presentation.pptx",
+    content_type:
+      "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+    size: 8901234,
+    upload_time: "2025-10-12T16:45:00Z",
+    owner: "john-doe",
+    collection: "test",
+    metadata: {
+      status: "Completed",
+      tags: ["meeting", "slides"],
+    },
+  },
+  {
+    object_name: "shared/participant/upload.pdf",
+    original_filename: "upload.pdf",
+    content_type: "application/pdf",
+    size: 1234567,
+    upload_time: "2025-10-12T11:20:00Z",
+    owner: "participant@example.com",
+    collection: "shared",
+    metadata: {
+      status: "Completed",
+      tags: ["submission"],
+    },
+  },
+  {
+    object_name: "shared/alice-jones/meeting-notes.docx",
+    original_filename: "meeting-notes.docx",
+    content_type:
+      "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+    size: 345678,
+    upload_time: "2025-10-11T11:30:00Z",
+    owner: "alice-jones",
+    collection: "shared",
+    metadata: {
+      status: "Completed",
+      tags: ["notes", "meeting"],
+    },
+  },
+];
+
+/**
+ * Admin user - full permissions
+ *
+ * Demonstrates admin capabilities:
+ * - Shows "Create Collection" button in collections grid
+ * - All files show full actions: Download, View History, Archive, Delete
+ */
+export const AdminUser: Story = {
+  decorators: [
+    (Story) => (
+      <MemoryRouter>
+        <MockAuthProvider user={mockAdminUser}>
+          <CollectionsProvider>
+            <FilesProvider>
+              <div className="min-h-screen bg-background p-8">
+                <Story />
+              </div>
+            </FilesProvider>
+          </CollectionsProvider>
+        </MockAuthProvider>
+      </MemoryRouter>
+    ),
+  ],
+  parameters: {
+    msw: {
+      handlers: [
+        http.get("http://localhost:8000/api/files/test", () => {
+          return HttpResponse.json({
+            files: mockFiles.filter((f) => f.collection === "test"),
+          });
+        }),
+        http.get("http://localhost:8000/api/files/restricted", () => {
+          return HttpResponse.json({
+            files: mockFiles.filter((f) => f.collection === "restricted"),
+          });
+        }),
+        http.get("http://localhost:8000/api/files/shared", () => {
+          return HttpResponse.json({
+            files: mockFiles.filter((f) => f.collection === "shared"),
+          });
+        }),
+      ],
+    },
+  },
+};
+
+/**
+ * Loading state - shows skeleton components
+ */
+export const Loading: Story = {
+  decorators: [
+    (Story) => (
+      <MemoryRouter>
+        <MockAuthProvider user={mockAdminUser}>
+          <CollectionsProvider>
+            <FilesProvider>
+              <div className="min-h-screen bg-background p-8">
+                <Story />
+              </div>
+            </FilesProvider>
+          </CollectionsProvider>
+        </MockAuthProvider>
+      </MemoryRouter>
+    ),
+  ],
+  parameters: {
+    msw: {
+      handlers: [
+        http.get("http://localhost:8000/api/files/*", async () => {
+          await delay("infinite");
+          return HttpResponse.json({ files: [] });
+        }),
+      ],
+    },
+  },
+};
+
+/**
+ * Empty state - user has no collections
+ */
+export const EmptyCollections: Story = {
+  decorators: [
+    (Story) => {
+      const emptyUser = {
+        ...mockAdminUser,
+        collections: {},
+      };
+
+      return (
+        <MemoryRouter>
+          <MockAuthProvider user={emptyUser}>
+            <CollectionsProvider>
+              <FilesProvider>
+                <div className="min-h-screen bg-background p-8">
+                  <Story />
+                </div>
+              </FilesProvider>
+            </CollectionsProvider>
+          </MockAuthProvider>
+        </MemoryRouter>
+      );
+    },
+  ],
+  parameters: {
+    msw: {
+      handlers: [
+        http.get("http://localhost:8000/api/files/*", () => {
+          return HttpResponse.json({ files: [] });
+        }),
+      ],
+    },
+  },
+};
+
+/**
+ * Empty files state - collections exist but no files uploaded
+ */
+export const EmptyFiles: Story = {
+  decorators: [
+    (Story) => (
+      <MemoryRouter>
+        <MockAuthProvider user={mockAdminUser}>
+          <CollectionsProvider>
+            <FilesProvider>
+              <div className="min-h-screen bg-background p-8">
+                <Story />
+              </div>
+            </FilesProvider>
+          </CollectionsProvider>
+        </MockAuthProvider>
+      </MemoryRouter>
+    ),
+  ],
+  parameters: {
+    msw: {
+      handlers: [
+        http.get("http://localhost:8000/api/files/test", () => {
+          return HttpResponse.json({ files: [] });
+        }),
+        http.get("http://localhost:8000/api/files/restricted", () => {
+          return HttpResponse.json({ files: [] });
+        }),
+        http.get("http://localhost:8000/api/files/shared", () => {
+          return HttpResponse.json({ files: [] });
+        }),
+      ],
+    },
+  },
+};
+
+/**
+ * Many collections - tests grid overflow
+ */
+export const ManyCollections: Story = {
+  decorators: [
+    (Story) => {
+      const manyCollectionsUser = {
+        ...mockAdminUser,
+        collections: Object.fromEntries(
+          Array.from({ length: 12 }, (_, i) => [
+            `collection-${i + 1}`,
+            ["read", "write", "delete"],
+          ]),
+        ),
+      };
+
+      return (
+        <MemoryRouter>
+          <MockAuthProvider user={manyCollectionsUser}>
+            <CollectionsProvider>
+              <FilesProvider>
+                <div className="min-h-screen bg-background p-8">
+                  <Story />
+                </div>
+              </FilesProvider>
+            </CollectionsProvider>
+          </MockAuthProvider>
+        </MemoryRouter>
+      );
+    },
+  ],
+  parameters: {
+    msw: {
+      handlers: [
+        http.get("http://localhost:8000/api/files/*", () => {
+          return HttpResponse.json({ files: mockFiles.slice(0, 2) });
+        }),
+      ],
+    },
+  },
+};
+
+/**
+ * Slow loading - simulates slow network
+ */
+export const SlowLoading: Story = {
+  decorators: [
+    (Story) => (
+      <MemoryRouter>
+        <MockAuthProvider user={mockAdminUser}>
+          <CollectionsProvider>
+            <FilesProvider>
+              <div className="min-h-screen bg-background p-8">
+                <Story />
+              </div>
+            </FilesProvider>
+          </CollectionsProvider>
+        </MockAuthProvider>
+      </MemoryRouter>
+    ),
+  ],
+  parameters: {
+    msw: {
+      handlers: [
+        http.get("http://localhost:8000/api/files/*", async () => {
+          await delay(2000);
+          return HttpResponse.json({ files: mockFiles });
+        }),
+      ],
+    },
+  },
+};
+
+/**
+ * Trust Architect user - full file permissions, but cannot create collections
+ *
+ * Demonstrates Trust Architect capabilities:
+ * - TODO: NO "Create Collection" button (only admins can create collections)
+ * - All files show full actions: Download, View History, Archive, Delete
+ */
+export const TrustArchitectUser: Story = {
+  decorators: [
+    (Story) => (
+      <MemoryRouter>
+        <MockAuthProvider user={mockTAUser}>
+          <CollectionsProvider>
+            <FilesProvider>
+              <div className="min-h-screen bg-background p-8">
+                <Story />
+              </div>
+            </FilesProvider>
+          </CollectionsProvider>
+        </MockAuthProvider>
+      </MemoryRouter>
+    ),
+  ],
+  parameters: {
+    msw: {
+      handlers: [
+        http.get("http://localhost:8000/api/files/test", () => {
+          return HttpResponse.json({
+            files: mockFiles.filter((f) => f.collection === "test"),
+          });
+        }),
+        http.get("http://localhost:8000/api/files/restricted", () => {
+          return HttpResponse.json({
+            files: mockFiles.filter((f) => f.collection === "restricted"),
+          });
+        }),
+        http.get("http://localhost:8000/api/files/shared", () => {
+          return HttpResponse.json({
+            files: mockFiles.filter((f) => f.collection === "shared"),
+          });
+        }),
+      ],
+    },
+  },
+};
+
+/**
+ * Participant user - limited file actions, no Create Collection button
+ *
+ * Demonstrates permission differences:
+ * - TODO: NO "Create Collection" button
+ * - Files owned by participant (my-data.xlsx, upload.pdf): Show "Download" action
+ * - Files owned by others (document-1.pdf, report-q3.xlsx, etc.): Show "No actions available" (disabled)
+ */
+export const ParticipantUser: Story = {
+  decorators: [
+    (Story) => (
+      <MemoryRouter>
+        <MockAuthProvider user={mockParticipantUser}>
+          <CollectionsProvider>
+            <FilesProvider>
+              <div className="min-h-screen bg-background p-8">
+                <Story />
+              </div>
+            </FilesProvider>
+          </CollectionsProvider>
+        </MockAuthProvider>
+      </MemoryRouter>
+    ),
+  ],
+  parameters: {
+    msw: {
+      handlers: [
+        http.get("http://localhost:8000/api/files/test", () => {
+          // Show all files in test collection to demonstrate permission differences
+          return HttpResponse.json({
+            files: mockFiles.filter((f) => f.collection === "test"),
+          });
+        }),
+        http.get("http://localhost:8000/api/files/shared", () => {
+          // Show all files in shared collection to demonstrate permission differences
+          return HttpResponse.json({
+            files: mockFiles.filter((f) => f.collection === "shared"),
+          });
+        }),
+      ],
+    },
+  },
+};

--- a/spa/src/pages/dashboard/Dashboard.test.tsx
+++ b/spa/src/pages/dashboard/Dashboard.test.tsx
@@ -1,0 +1,521 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { Dashboard } from "./Dashboard";
+
+// Mock dependencies
+const mockNavigate = vi.fn();
+const mockFetchCollections = vi.fn();
+const mockFetchRecentFiles = vi.fn();
+const mockHandleDownload = vi.fn();
+const mockHandleViewHistory = vi.fn();
+const mockHandleDelete = vi.fn();
+const mockHandleArchive = vi.fn();
+const mockDeleteDialogOnConfirm = vi.fn();
+const mockDeleteDialogOnCancel = vi.fn();
+const mockArchiveDialogOnConfirm = vi.fn();
+const mockArchiveDialogOnCancel = vi.fn();
+
+vi.mock("react-router-dom", () => ({
+  useNavigate: () => mockNavigate,
+}));
+
+vi.mock("@/contexts/collections", () => ({
+  useCollections: vi.fn(),
+}));
+
+vi.mock("@/contexts/files", () => ({
+  useFiles: vi.fn(),
+}));
+
+vi.mock("@/hooks/file", () => ({
+  useFileActions: vi.fn(),
+}));
+
+vi.mock("sonner", () => ({
+  toast: {
+    info: vi.fn(),
+  },
+}));
+
+vi.mock("react-oidc-context", () => ({
+  useAuth: () => ({
+    user: {
+      profile: {
+        preferred_username: "testuser",
+        given_name: "Test",
+        family_name: "User",
+        email: "test@example.com",
+        collections: {
+          test: ["read", "write", "delete"],
+        },
+      },
+    },
+    isAuthenticated: true,
+    isLoading: false,
+  }),
+}));
+
+// Import mocked modules to access their mock implementations
+import { useCollections } from "@/contexts/collections";
+import { useFiles } from "@/contexts/files";
+import { useFileActions } from "@/hooks/file";
+
+const mockCollections = [
+  { id: "collection-1", name: "Collection 1", fileCount: 10 },
+  { id: "collection-2", name: "Collection 2", fileCount: 5 },
+];
+
+const mockFiles = [
+  {
+    object_name: "test/user/file1.pdf",
+    original_filename: "file1.pdf",
+    content_type: "application/pdf",
+    size: 1024,
+    upload_time: "2024-01-01T00:00:00Z",
+    owner: "user@example.com",
+    collection: "test",
+  },
+  {
+    object_name: "test/user/file2.pdf",
+    original_filename: "file2.pdf",
+    content_type: "application/pdf",
+    size: 2048,
+    upload_time: "2024-01-02T00:00:00Z",
+    owner: "user@example.com",
+    collection: "test",
+  },
+];
+
+describe("Dashboard", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    // Default mock implementations
+    vi.mocked(useCollections).mockReturnValue({
+      collections: mockCollections,
+      fetchCollections: mockFetchCollections,
+      loading: false,
+      error: null,
+    });
+
+    vi.mocked(useFiles).mockReturnValue({
+      files: mockFiles,
+      fetchRecentFiles: mockFetchRecentFiles,
+      loading: false,
+      error: null,
+      fetchFiles: vi.fn(),
+      uploadFile: vi.fn(),
+      downloadFile: vi.fn(),
+      downloadFiles: vi.fn(),
+      deleteFile: vi.fn(),
+      archiveFile: vi.fn(),
+      totalPages: 1,
+      currentPage: 1,
+      totalCount: 2,
+    });
+
+    vi.mocked(useFileActions).mockReturnValue({
+      handleDownload: mockHandleDownload,
+      handleViewHistory: mockHandleViewHistory,
+      handleDelete: mockHandleDelete,
+      handleArchive: mockHandleArchive,
+      deleteDialog: {
+        open: false,
+        file: null,
+        isLoading: false,
+        onConfirm: mockDeleteDialogOnConfirm,
+        onCancel: mockDeleteDialogOnCancel,
+      },
+      archiveDialog: {
+        open: false,
+        file: null,
+        isLoading: false,
+        onConfirm: mockArchiveDialogOnConfirm,
+        onCancel: mockArchiveDialogOnCancel,
+      },
+    });
+  });
+
+  describe("Rendering", () => {
+    it("renders the dashboard with title", () => {
+      render(<Dashboard />);
+      expect(screen.getByTestId("dashboard-heading")).toHaveTextContent(
+        "Files",
+      );
+    });
+
+    it("renders collections grid", () => {
+      render(<Dashboard />);
+      expect(screen.getByTestId("collections-grid")).toBeInTheDocument();
+      expect(
+        screen.getByTestId("collection-card-collection-1"),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByTestId("collection-card-collection-2"),
+      ).toBeInTheDocument();
+    });
+
+    it("renders recent files table", () => {
+      render(<Dashboard />);
+      expect(screen.getByText("file1.pdf")).toBeInTheDocument();
+      expect(screen.getByText("file2.pdf")).toBeInTheDocument();
+    });
+
+    it("renders upload button when not loading", () => {
+      render(<Dashboard />);
+      expect(screen.getByTestId("upload-button")).toBeInTheDocument();
+    });
+
+    it("renders skeleton when collections are loading", () => {
+      vi.mocked(useCollections).mockReturnValue({
+        collections: [],
+        fetchCollections: mockFetchCollections,
+        loading: true,
+        error: null,
+      });
+
+      render(<Dashboard />);
+      expect(screen.getByTestId("upload-button-skeleton")).toBeInTheDocument();
+      expect(
+        screen.getByTestId("collections-grid-loading"),
+      ).toBeInTheDocument();
+      expect(screen.getByTestId("collection-skeleton-1")).toBeInTheDocument();
+    });
+  });
+
+  describe("Data Fetching", () => {
+    it("fetches collections and recent files on mount", () => {
+      render(<Dashboard />);
+      expect(mockFetchCollections).toHaveBeenCalled();
+      expect(mockFetchRecentFiles).toHaveBeenCalled();
+    });
+  });
+
+  describe("Navigation", () => {
+    it("navigates to collection details when collection is clicked", async () => {
+      const user = userEvent.setup();
+      render(<Dashboard />);
+
+      const viewButton = screen.getByTestId("view-button-collection-1");
+      await user.click(viewButton);
+
+      expect(mockNavigate).toHaveBeenCalledWith("/collections/collection-1");
+    });
+
+    it("navigates to upload page when upload button is clicked", async () => {
+      const user = userEvent.setup();
+      render(<Dashboard />);
+
+      const uploadButton = screen.getByTestId("upload-button");
+      await user.click(uploadButton);
+
+      expect(mockNavigate).toHaveBeenCalledWith("/upload");
+    });
+  });
+
+  describe("File Actions", () => {
+    it("passes file action handlers to RecentFilesTable", () => {
+      render(<Dashboard />);
+
+      // Verify the handlers are available by checking they were passed to useFileActions
+      expect(useFileActions).toHaveBeenCalled();
+    });
+  });
+
+  describe("Delete Dialog", () => {
+    it("does not render delete dialog when closed", () => {
+      render(<Dashboard />);
+      expect(screen.queryByTestId("confirm-dialog")).not.toBeInTheDocument();
+    });
+
+    it("renders delete dialog when open", () => {
+      vi.mocked(useFileActions).mockReturnValue({
+        handleDownload: mockHandleDownload,
+        handleViewHistory: mockHandleViewHistory,
+        handleDelete: mockHandleDelete,
+        handleArchive: mockHandleArchive,
+        deleteDialog: {
+          open: true,
+          file: mockFiles[0],
+          isLoading: false,
+          onConfirm: mockDeleteDialogOnConfirm,
+          onCancel: mockDeleteDialogOnCancel,
+        },
+        archiveDialog: {
+          open: false,
+          file: null,
+          isLoading: false,
+          onConfirm: mockArchiveDialogOnConfirm,
+          onCancel: mockArchiveDialogOnCancel,
+        },
+      });
+
+      render(<Dashboard />);
+      expect(screen.getByTestId("confirm-dialog-title")).toHaveTextContent(
+        "Delete file",
+      );
+      expect(
+        screen.getByTestId("confirm-dialog-description"),
+      ).toHaveTextContent(
+        "Are you sure you want to delete this file? This action can't be undone.",
+      );
+    });
+
+    it("shows loading state in delete dialog", () => {
+      vi.mocked(useFileActions).mockReturnValue({
+        handleDownload: mockHandleDownload,
+        handleViewHistory: mockHandleViewHistory,
+        handleDelete: mockHandleDelete,
+        handleArchive: mockHandleArchive,
+        deleteDialog: {
+          open: true,
+          file: mockFiles[0],
+          isLoading: true,
+          onConfirm: mockDeleteDialogOnConfirm,
+          onCancel: mockDeleteDialogOnCancel,
+        },
+        archiveDialog: {
+          open: false,
+          file: null,
+          isLoading: false,
+          onConfirm: mockArchiveDialogOnConfirm,
+          onCancel: mockArchiveDialogOnCancel,
+        },
+      });
+
+      render(<Dashboard />);
+      const confirmButton = screen.getByTestId("confirm-dialog-confirm");
+      expect(confirmButton).toHaveTextContent("Deleting...");
+    });
+
+    it("calls onConfirm when delete is confirmed", async () => {
+      const user = userEvent.setup();
+
+      vi.mocked(useFileActions).mockReturnValue({
+        handleDownload: mockHandleDownload,
+        handleViewHistory: mockHandleViewHistory,
+        handleDelete: mockHandleDelete,
+        handleArchive: mockHandleArchive,
+        deleteDialog: {
+          open: true,
+          file: mockFiles[0],
+          isLoading: false,
+          onConfirm: mockDeleteDialogOnConfirm,
+          onCancel: mockDeleteDialogOnCancel,
+        },
+        archiveDialog: {
+          open: false,
+          file: null,
+          isLoading: false,
+          onConfirm: mockArchiveDialogOnConfirm,
+          onCancel: mockArchiveDialogOnCancel,
+        },
+      });
+
+      render(<Dashboard />);
+
+      const confirmButton = screen.getByTestId("confirm-dialog-confirm");
+      await user.click(confirmButton);
+
+      expect(mockDeleteDialogOnConfirm).toHaveBeenCalled();
+    });
+
+    it("calls onCancel when delete is cancelled", async () => {
+      const user = userEvent.setup();
+
+      vi.mocked(useFileActions).mockReturnValue({
+        handleDownload: mockHandleDownload,
+        handleViewHistory: mockHandleViewHistory,
+        handleDelete: mockHandleDelete,
+        handleArchive: mockHandleArchive,
+        deleteDialog: {
+          open: true,
+          file: mockFiles[0],
+          isLoading: false,
+          onConfirm: mockDeleteDialogOnConfirm,
+          onCancel: mockDeleteDialogOnCancel,
+        },
+        archiveDialog: {
+          open: false,
+          file: null,
+          isLoading: false,
+          onConfirm: mockArchiveDialogOnConfirm,
+          onCancel: mockArchiveDialogOnCancel,
+        },
+      });
+
+      render(<Dashboard />);
+
+      const cancelButton = screen.getByTestId("confirm-dialog-cancel");
+      await user.click(cancelButton);
+
+      expect(mockDeleteDialogOnCancel).toHaveBeenCalled();
+    });
+  });
+
+  describe("Archive Dialog", () => {
+    it("does not render archive dialog when closed", () => {
+      render(<Dashboard />);
+      // Only one dialog is rendered, and it's closed
+      expect(screen.queryByTestId("confirm-dialog")).not.toBeInTheDocument();
+    });
+
+    it("renders archive dialog when open", () => {
+      vi.mocked(useFileActions).mockReturnValue({
+        handleDownload: mockHandleDownload,
+        handleViewHistory: mockHandleViewHistory,
+        handleDelete: mockHandleDelete,
+        handleArchive: mockHandleArchive,
+        deleteDialog: {
+          open: false,
+          file: null,
+          isLoading: false,
+          onConfirm: mockDeleteDialogOnConfirm,
+          onCancel: mockDeleteDialogOnCancel,
+        },
+        archiveDialog: {
+          open: true,
+          file: mockFiles[0],
+          isLoading: false,
+          onConfirm: mockArchiveDialogOnConfirm,
+          onCancel: mockArchiveDialogOnCancel,
+        },
+      });
+
+      render(<Dashboard />);
+      expect(screen.getByTestId("confirm-dialog-title")).toHaveTextContent(
+        "Archive file",
+      );
+      expect(
+        screen.getByTestId("confirm-dialog-description"),
+      ).toHaveTextContent("Are you sure you want to archive this file?");
+    });
+
+    it("shows loading state in archive dialog", () => {
+      vi.mocked(useFileActions).mockReturnValue({
+        handleDownload: mockHandleDownload,
+        handleViewHistory: mockHandleViewHistory,
+        handleDelete: mockHandleDelete,
+        handleArchive: mockHandleArchive,
+        deleteDialog: {
+          open: false,
+          file: null,
+          isLoading: false,
+          onConfirm: mockDeleteDialogOnConfirm,
+          onCancel: mockDeleteDialogOnCancel,
+        },
+        archiveDialog: {
+          open: true,
+          file: mockFiles[0],
+          isLoading: true,
+          onConfirm: mockArchiveDialogOnConfirm,
+          onCancel: mockArchiveDialogOnCancel,
+        },
+      });
+
+      render(<Dashboard />);
+      const confirmButton = screen.getByTestId("confirm-dialog-confirm");
+      expect(confirmButton).toHaveTextContent("Archiving...");
+    });
+
+    it("calls onConfirm when archive is confirmed", async () => {
+      const user = userEvent.setup();
+
+      vi.mocked(useFileActions).mockReturnValue({
+        handleDownload: mockHandleDownload,
+        handleViewHistory: mockHandleViewHistory,
+        handleDelete: mockHandleDelete,
+        handleArchive: mockHandleArchive,
+        deleteDialog: {
+          open: false,
+          file: null,
+          isLoading: false,
+          onConfirm: mockDeleteDialogOnConfirm,
+          onCancel: mockDeleteDialogOnCancel,
+        },
+        archiveDialog: {
+          open: true,
+          file: mockFiles[0],
+          isLoading: false,
+          onConfirm: mockArchiveDialogOnConfirm,
+          onCancel: mockArchiveDialogOnCancel,
+        },
+      });
+
+      render(<Dashboard />);
+
+      const confirmButton = screen.getByTestId("confirm-dialog-confirm");
+      await user.click(confirmButton);
+
+      expect(mockArchiveDialogOnConfirm).toHaveBeenCalled();
+    });
+
+    it("calls onCancel when archive is cancelled", async () => {
+      const user = userEvent.setup();
+
+      vi.mocked(useFileActions).mockReturnValue({
+        handleDownload: mockHandleDownload,
+        handleViewHistory: mockHandleViewHistory,
+        handleDelete: mockHandleDelete,
+        handleArchive: mockHandleArchive,
+        deleteDialog: {
+          open: false,
+          file: null,
+          isLoading: false,
+          onConfirm: mockDeleteDialogOnConfirm,
+          onCancel: mockDeleteDialogOnCancel,
+        },
+        archiveDialog: {
+          open: true,
+          file: mockFiles[0],
+          isLoading: false,
+          onConfirm: mockArchiveDialogOnConfirm,
+          onCancel: mockArchiveDialogOnCancel,
+        },
+      });
+
+      render(<Dashboard />);
+
+      const cancelButton = screen.getByTestId("confirm-dialog-cancel");
+      await user.click(cancelButton);
+
+      expect(mockArchiveDialogOnCancel).toHaveBeenCalled();
+    });
+  });
+
+  describe("Empty States", () => {
+    it("renders with no collections", () => {
+      vi.mocked(useCollections).mockReturnValue({
+        collections: [],
+        fetchCollections: mockFetchCollections,
+        loading: false,
+        error: null,
+      });
+
+      render(<Dashboard />);
+      expect(screen.getByText("Files")).toBeInTheDocument();
+    });
+
+    it("renders with no files", () => {
+      vi.mocked(useFiles).mockReturnValue({
+        files: [],
+        fetchRecentFiles: mockFetchRecentFiles,
+        loading: false,
+        error: null,
+        fetchFiles: vi.fn(),
+        uploadFile: vi.fn(),
+        downloadFile: vi.fn(),
+        downloadFiles: vi.fn(),
+        deleteFile: vi.fn(),
+        archiveFile: vi.fn(),
+        totalPages: 0,
+        currentPage: 1,
+        totalCount: 0,
+      });
+
+      render(<Dashboard />);
+      expect(screen.getByText("Files")).toBeInTheDocument();
+    });
+  });
+});

--- a/spa/src/pages/dashboard/Dashboard.tsx
+++ b/spa/src/pages/dashboard/Dashboard.tsx
@@ -1,0 +1,122 @@
+import { CollectionsGrid } from "@/components/collection/collections-grid";
+import { UploadButton } from "@/components/collection/upload-button";
+import { ConfirmDialog } from "@/components/dialogs/ConfirmDialog";
+import { RecentFilesTable } from "@/components/table/recent-files-table";
+import { Skeleton } from "@/components/ui/skeleton";
+import { useCollections } from "@/contexts/collections";
+import { useFiles } from "@/contexts/files";
+import { useFileActions } from "@/hooks/file";
+import { useEffect } from "react";
+import { useNavigate } from "react-router-dom";
+import { toast } from "sonner";
+
+export function Dashboard() {
+  const navigate = useNavigate();
+  const {
+    collections,
+    fetchCollections,
+    loading: collectionsLoading,
+  } = useCollections();
+  const { files, fetchRecentFiles, loading } = useFiles();
+
+  // Get file action handlers with refetch callback
+  const refetchRecentFiles = () => {
+    fetchRecentFiles();
+    fetchCollections(); // Also refresh collections to update counts
+  };
+
+  const {
+    handleDownload,
+    handleViewHistory,
+    handleDelete,
+    handleArchive,
+    deleteDialog,
+    archiveDialog,
+  } = useFileActions(refetchRecentFiles);
+
+  useEffect(() => {
+    fetchCollections();
+    fetchRecentFiles();
+  }, [fetchCollections, fetchRecentFiles]);
+
+  const handleCollectionClick = (collectionId: string) => {
+    navigate(`/collections/${collectionId}`);
+  };
+
+  const handleCollectionSettings = (collectionId: string) => {
+    navigate(`/collections/${collectionId}/config`);
+  };
+
+  const handleCreateCollection = () => {
+    // TODO: Implement create collection functionality
+    toast.info("TODO: Create collection functionality not yet implemented");
+  };
+
+  const handleUploadFiles = () => {
+    navigate(`/upload`);
+  };
+
+  return (
+    <div className="flex flex-col gap-14">
+      {/* Header */}
+      <div className="flex justify-between items-center">
+        <h1
+          className="text-3xl font-extrabold leading-10 text-foreground"
+          data-testid="dashboard-heading"
+        >
+          Files
+        </h1>
+        {collectionsLoading ? (
+          <Skeleton
+            className="h-10 w-32"
+            data-testid="upload-button-skeleton"
+          />
+        ) : (
+          <UploadButton onClick={handleUploadFiles} />
+        )}
+      </div>
+
+      {/* Collections Grid */}
+      <CollectionsGrid
+        collections={collections}
+        loading={collectionsLoading}
+        onCollectionClick={handleCollectionClick}
+        onCollectionSettings={handleCollectionSettings}
+        onCreateCollection={handleCreateCollection}
+      />
+
+      {/* Recent Files Table */}
+      <RecentFilesTable
+        files={files}
+        loading={loading}
+        onDownload={handleDownload}
+        onDelete={handleDelete}
+        onViewHistory={handleViewHistory}
+        onArchive={handleArchive}
+      />
+
+      {/* Confirmation Dialogs */}
+      <ConfirmDialog
+        open={deleteDialog.open}
+        title="Delete file"
+        description="Are you sure you want to delete this file? This action can't be undone."
+        confirmText="Delete"
+        loadingText="Deleting..."
+        isLoading={deleteDialog.isLoading}
+        onConfirm={deleteDialog.onConfirm}
+        onCancel={deleteDialog.onCancel}
+      />
+
+      <ConfirmDialog
+        open={archiveDialog.open}
+        title="Archive file"
+        description="Are you sure you want to archive this file?"
+        confirmText="Archive"
+        loadingText="Archiving..."
+        isLoading={archiveDialog.isLoading}
+        onConfirm={archiveDialog.onConfirm}
+        onCancel={archiveDialog.onCancel}
+      />
+    </div>
+  );
+}

--- a/spa/src/pages/sign-in/SignIn.stories.tsx
+++ b/spa/src/pages/sign-in/SignIn.stories.tsx
@@ -1,10 +1,10 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
-import { SignIn } from "./SignIn";
 import { AuthProvider } from "react-oidc-context";
 import { MemoryRouter } from "react-router-dom";
+import { SignIn } from "./SignIn";
 
 const meta = {
-  title: "Pages/SignIn/SignIn",
+  title: "Pages/SignIn",
   component: SignIn,
   parameters: {
     layout: "fullscreen",

--- a/spa/src/services/collections/collectionsService.test.ts
+++ b/spa/src/services/collections/collectionsService.test.ts
@@ -20,6 +20,7 @@ describe("CollectionsService", () => {
   describe("getCollections", () => {
     it("returns collections with file counts when all requests succeed", async () => {
       const mockUser: User = {
+        username: "testuser",
         name: "Test User",
         email: "test@example.com",
         roles: [],
@@ -51,6 +52,7 @@ describe("CollectionsService", () => {
 
     it("handles partial failures gracefully", async () => {
       const mockUser: User = {
+        username: "testuser",
         name: "Test User",
         email: "test@example.com",
         roles: [],
@@ -82,6 +84,7 @@ describe("CollectionsService", () => {
 
     it("returns all collections with zero counts when all requests fail", async () => {
       const mockUser: User = {
+        username: "testuser",
         name: "Test User",
         email: "test@example.com",
         roles: [],
@@ -114,6 +117,7 @@ describe("CollectionsService", () => {
 
     it("handles NotFoundError with correct action", async () => {
       const mockUser: User = {
+        username: "testuser",
         name: "Test User",
         email: "test@example.com",
         roles: [],
@@ -135,6 +139,7 @@ describe("CollectionsService", () => {
 
     it("handles ForbiddenError with correct action", async () => {
       const mockUser: User = {
+        username: "testuser",
         name: "Test User",
         email: "test@example.com",
         roles: [],
@@ -156,6 +161,7 @@ describe("CollectionsService", () => {
 
     it("returns empty arrays for user with no collections", async () => {
       const mockUser: User = {
+        username: "testuser",
         name: "Test User",
         email: "test@example.com",
         roles: [],
@@ -171,6 +177,7 @@ describe("CollectionsService", () => {
 
     it("handles user with undefined collections", async () => {
       const mockUser: User = {
+        username: "testuser",
         name: "Test User",
         email: "test@example.com",
         roles: [],
@@ -186,6 +193,7 @@ describe("CollectionsService", () => {
 
     it("handles response with no files array", async () => {
       const mockUser: User = {
+        username: "testuser",
         name: "Test User",
         email: "test@example.com",
         roles: [],
@@ -205,6 +213,7 @@ describe("CollectionsService", () => {
 
     it("handles response with empty files array", async () => {
       const mockUser: User = {
+        username: "testuser",
         name: "Test User",
         email: "test@example.com",
         roles: [],
@@ -224,6 +233,7 @@ describe("CollectionsService", () => {
 
     it("handles unexpected error", async () => {
       const mockUser: User = {
+        username: "testuser",
         name: "Test User",
         email: "test@example.com",
         roles: [],
@@ -249,6 +259,7 @@ describe("CollectionsService", () => {
 
     it("makes correct API calls for each collection", async () => {
       const mockUser: User = {
+        username: "testuser",
         name: "Test User",
         email: "test@example.com",
         roles: [],

--- a/spa/src/services/files/filesService.test.ts
+++ b/spa/src/services/files/filesService.test.ts
@@ -294,6 +294,7 @@ describe("FilesService", () => {
 
   describe("getRecentFiles", () => {
     const mockUser: User = {
+      username: "testuser",
       name: "Test User",
       email: "test@example.com",
       roles: [],

--- a/spa/src/types/index.ts
+++ b/spa/src/types/index.ts
@@ -34,7 +34,8 @@ export enum UserRole {
  * Represents a user in the system
  */
 export interface User {
-  name: string;
+  username: string; // Keycloak preferred_username - used for file ownership
+  name: string; // Display name (full name or username)
   email: string;
   avatarUrl?: string;
   roles: UserRole[];


### PR DESCRIPTION
This PR introduces a dashboard to the SPA and updates related types, Storybook configuration, service worker, and supporting components/hooks.

Closes issue [#130](https://github.com/gs-gs/pyx-rbtp/issues/130)
<img width="1488" height="1032" alt="Screenshot 2025-11-12 at 8 35 15 am" src="https://github.com/user-attachments/assets/954fe280-c6d3-44fa-8cc2-a93d88f6f5d3" />
<img width="735" height="1032" alt="Screenshot 2025-11-12 at 8 35 34 am" src="https://github.com/user-attachments/assets/4a3e14b9-154d-49ef-9da0-1ebc093b4e40" />
<img width="735" height="1032" alt="Screenshot 2025-11-12 at 8 35 38 am" src="https://github.com/user-attachments/assets/288d6062-a540-4127-8d7b-afdf025a94f5" />

