### PR TITLE
ci: update origin url regex

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,7 +130,7 @@ jobs:
     name: Publish Container Images
     runs-on: ubuntu-latest
     needs: e2e-tests
-    if: success()
+    if: success() && github.ref == 'refs/heads/master'
     permissions:
       contents: read
       packages: write


### PR DESCRIPTION
This PR fixes #67 by consolidating and updating the regex used to extract the repository owner and name in the container-build/publish targets, ensuring it also handles origin URLs that don’t include the `.git` suffix.

Pipeline run - https://github.com/pyx-industries/stuf/actions/runs/20041711012/job/57478281462
Resulting images - https://github.com/orgs/pyx-industries/packages?repo_name=stuf