### PR TITLE
feat: add spa entrypoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,10 @@ tests/.venv/
 spa/build/
 spa/dist/
 
+# Runtime-generated config files
+spa/public/config.js
+spa/build/config.js
+
 # Coverage reports
 api/htmlcov/
 api/.coverage

--- a/Makefile
+++ b/Makefile
@@ -110,6 +110,8 @@ clean:
 	@echo "Cleaning Keycloak database..."
 	@rm -rf docker/keycloak/data/h2
 	@rm -rf docker/keycloak/data/transaction-logs
+	@echo "Cleaning SPA generated config..."
+	@rm -f spa/public/config.js spa/build/config.js
 	@echo "Clean complete."
 
 # Test targets
@@ -169,6 +171,8 @@ spa-stop:
 	@echo "Cleaning Keycloak database..."
 	@rm -rf docker/keycloak/data/h2
 	@rm -rf docker/keycloak/data/transaction-logs
+	@echo "Cleaning generated config..."
+	@rm -f spa/public/config.js spa/build/config.js
 
 # Container building and publishing targets
 

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -31,5 +31,3 @@ services:
     environment:
       # Enable file watching in Docker
       - CHOKIDAR_USEPOLLING=true
-      - VITE_HMRPORT=3000
-    command: npm run dev

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -71,10 +71,10 @@ services:
     ports:
       - "${SPA_PORT:-3000}:3000"
     environment:
-      - REACT_APP_API_URL=${API_URL:-http://localhost:8000}
-      - REACT_APP_KEYCLOAK_URL=${KEYCLOAK_URL:-http://localhost:8080}
-      - REACT_APP_KEYCLOAK_REALM=${KEYCLOAK_REALM:-stuf}
-      - REACT_APP_KEYCLOAK_CLIENT_ID=${KEYCLOAK_SPA_CLIENT_ID:-stuf-spa}
+      - API_URL=${API_URL:-http://localhost:8000}
+      - KEYCLOAK_URL=${KEYCLOAK_URL:-http://localhost:8080}
+      - KEYCLOAK_REALM=${KEYCLOAK_REALM:-stuf}
+      - KEYCLOAK_CLIENT_ID=${KEYCLOAK_SPA_CLIENT_ID:-stuf-spa}
     depends_on:
       - api
 

--- a/spa/Dockerfile
+++ b/spa/Dockerfile
@@ -20,10 +20,12 @@ COPY index.html ./
 # Copy source code
 COPY src/ ./src/
 
-EXPOSE 3000
+# Copy and set up the entrypoint script
+COPY docker-entrypoint.sh /app/docker-entrypoint.sh
+RUN chmod +x /app/docker-entrypoint.sh
 
-# Use Vite dev server for development
-CMD ["npm", "run", "dev", "--", "--host", "0.0.0.0"]
+# Use entrypoint with "dev" argument
+ENTRYPOINT ["/app/docker-entrypoint.sh", "dev"]
 
 # Production stage
 FROM node:20-alpine AS production
@@ -53,6 +55,9 @@ RUN npm install vite @vitejs/plugin-react --save-dev
 # Build the application
 RUN npm run build
 
-# Use Vite preview server for production
-EXPOSE 3000
-CMD ["npm", "run", "preview", "--", "--host", "0.0.0.0", "--port", "3000"]
+# Copy and set up the entrypoint script
+COPY docker-entrypoint.sh /app/docker-entrypoint.sh
+RUN chmod +x /app/docker-entrypoint.sh
+
+# Use entrypoint with "prod" argument (default)
+ENTRYPOINT ["/app/docker-entrypoint.sh", "prod"]

--- a/spa/README.md
+++ b/spa/README.md
@@ -1,0 +1,74 @@
+# STUF SPA
+
+React-based Single Page Application for the Secure Trusted Upload Facility.
+
+## Development
+
+### With Docker (Recommended)
+
+From the project root:
+
+```bash
+make spa-dev
+```
+
+This starts the full stack (Keycloak, MinIO, API, SPA) with hot reloading. Configuration is automatically injected from the root `.env` file.
+
+### Without Docker
+
+```bash
+cd spa
+npm install
+npm run dev
+```
+
+**Note:** When running without Docker, the SPA uses hardcoded defaults:
+
+| Setting            | Default Value           |
+| ------------------ | ----------------------- |
+| API URL            | `http://localhost:8000` |
+| Keycloak URL       | `http://localhost:8080` |
+| Keycloak Realm     | `stuf`                  |
+| Keycloak Client ID | `stuf-spa`              |
+
+If your local setup differs from these defaults, use `make spa-dev` instead, which reads from the root `.env` file.
+
+### Switching Between Docker and Non-Docker
+
+When switching between `make spa-dev` (Docker) and `npm run dev` (non-Docker), you may need to remove the generated config file:
+
+```bash
+rm spa/public/config.js
+```
+
+Or use the cleanup commands from the project root:
+
+```bash
+make spa-stop  # Stops services and cleans config
+make clean     # Full cleanup including config
+```
+
+**Why?** Docker mode generates `public/config.js` with runtime configuration. If this file exists when running `npm run dev` outside Docker, it will override the hardcoded defaults and may point to incorrect URLs (e.g., Docker container hostnames).
+
+## Configuration System
+
+The SPA uses a runtime configuration approach:
+
+1. **Docker deployments**: `docker-entrypoint.sh` generates `public/config.js` at container startup, injecting environment variables as `window.__STUF_CONFIG__`
+
+2. **Local development**: Falls back to hardcoded defaults in `src/config.ts` (only if `config.js` doesn't exist)
+
+This allows the same Docker image to be deployed to different environments (dev, staging, prod) without rebuilding.
+
+## Testing
+
+```bash
+npm test        # Run tests
+npm run test:ui # Run tests with UI
+```
+
+## Building
+
+```bash
+npm run build   # Production build (outputs to build/)
+```

--- a/spa/docker-entrypoint.sh
+++ b/spa/docker-entrypoint.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+set -e
+
+# Default values
+DEFAULT_API_BASE_URL="http://localhost:8000"
+DEFAULT_KEYCLOAK_URL="http://localhost:8080"
+DEFAULT_KEYCLOAK_REALM="stuf"
+DEFAULT_KEYCLOAK_CLIENT_ID="stuf-spa"
+
+# Check for missing environment variables and warn
+if [ -z "$API_URL" ]; then
+  echo "WARNING: API_URL not set, using default: $DEFAULT_API_BASE_URL"
+fi
+
+if [ -z "$KEYCLOAK_URL" ]; then
+  echo "WARNING: KEYCLOAK_URL not set, using default: $DEFAULT_KEYCLOAK_URL"
+fi
+
+if [ -z "$KEYCLOAK_REALM" ]; then
+  echo "WARNING: KEYCLOAK_REALM not set, using default: $DEFAULT_KEYCLOAK_REALM"
+fi
+
+if [ -z "$KEYCLOAK_CLIENT_ID" ]; then
+  echo "WARNING: KEYCLOAK_CLIENT_ID not set, using default: $DEFAULT_KEYCLOAK_CLIENT_ID"
+fi
+
+# Get values from environment or use defaults
+API_BASE_URL="${API_URL:-$DEFAULT_API_BASE_URL}"
+KEYCLOAK_URL="${KEYCLOAK_URL:-$DEFAULT_KEYCLOAK_URL}"
+KEYCLOAK_REALM="${KEYCLOAK_REALM:-$DEFAULT_KEYCLOAK_REALM}"
+KEYCLOAK_CLIENT_ID="${KEYCLOAK_CLIENT_ID:-$DEFAULT_KEYCLOAK_CLIENT_ID}"
+
+# Determine the mode (dev or prod) - default to prod
+MODE="${1:-prod}"
+
+# Get port from environment or use default
+SPA_PORT="${SPA_PORT:-3000}"
+
+# Generate config.js in the appropriate location
+if [ "$MODE" = "dev" ]; then
+  # For development, Vite serves from public/
+  mkdir -p /app/public
+  CONFIG_PATH="/app/public/config.js"
+else
+  # For production, serve from build/
+  CONFIG_PATH="/app/build/config.js"
+fi
+
+cat > "$CONFIG_PATH" <<EOF
+window.__STUF_CONFIG__ = {
+  apiBaseUrl: "$API_BASE_URL",
+  keycloakUrl: "$KEYCLOAK_URL",
+  keycloakRealm: "$KEYCLOAK_REALM",
+  keycloakClientId: "$KEYCLOAK_CLIENT_ID"
+};
+EOF
+
+echo "Generated runtime configuration at $CONFIG_PATH:"
+echo "  API Base URL: $API_BASE_URL"
+echo "  Keycloak URL: $KEYCLOAK_URL"
+echo "  Keycloak Realm: $KEYCLOAK_REALM"
+echo "  Keycloak Client ID: $KEYCLOAK_CLIENT_ID"
+echo "  Port: $SPA_PORT"
+
+# Start the appropriate server based on mode
+if [ "$MODE" = "dev" ]; then
+  echo "Starting Vite dev server on port $SPA_PORT..."
+  exec npm run dev -- --host 0.0.0.0 --port "$SPA_PORT"
+else
+  echo "Starting Vite preview server on port $SPA_PORT..."
+  exec npm run preview -- --host 0.0.0.0 --port "$SPA_PORT"
+fi

--- a/spa/index.html
+++ b/spa/index.html
@@ -16,6 +16,7 @@
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>
     <div id="root"></div>
+    <script src="/config.js"></script>
     <script type="module" src="/src/index.tsx"></script>
   </body>
 </html>

--- a/spa/src/config.test.ts
+++ b/spa/src/config.test.ts
@@ -1,0 +1,108 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { StufConfig } from "./config";
+import { getConfig } from "./config";
+
+describe("getConfig", () => {
+  let originalConfig: StufConfig | undefined;
+
+  beforeEach(() => {
+    // Clear the config cache by reimporting the module
+    vi.resetModules();
+    // Save the original config if it exists
+    originalConfig = window.__STUF_CONFIG__;
+    // Clear console.warn to avoid noise in test output
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    // Restore original config
+    if (originalConfig) {
+      window.__STUF_CONFIG__ = originalConfig;
+    } else {
+      delete window.__STUF_CONFIG__;
+    }
+    vi.restoreAllMocks();
+  });
+
+  it("returns defaults when window.__STUF_CONFIG__ is undefined", async () => {
+    delete window.__STUF_CONFIG__;
+
+    // Need to re-import to clear the cache
+    const { getConfig: freshGetConfig } = await import("./config");
+
+    const config = freshGetConfig();
+
+    expect(config).toEqual({
+      apiBaseUrl: "http://localhost:8000",
+      keycloakUrl: "http://localhost:8080",
+      keycloakRealm: "stuf",
+      keycloakClientId: "stuf-spa",
+    });
+  });
+
+  it("returns runtime config when window.__STUF_CONFIG__ is set", async () => {
+    const runtimeConfig: StufConfig = {
+      apiBaseUrl: "https://api.example.com",
+      keycloakUrl: "https://auth.example.com",
+      keycloakRealm: "production",
+      keycloakClientId: "prod-client",
+    };
+
+    window.__STUF_CONFIG__ = runtimeConfig;
+
+    // Need to re-import to clear the cache
+    const { getConfig: freshGetConfig } = await import("./config");
+
+    const config = freshGetConfig();
+
+    expect(config).toEqual(runtimeConfig);
+  });
+
+  it("logs warning when using defaults", async () => {
+    delete window.__STUF_CONFIG__;
+
+    // Need to re-import to clear the cache
+    const { getConfig: freshGetConfig } = await import("./config");
+
+    freshGetConfig();
+
+    expect(console.warn).toHaveBeenCalledWith(
+      "STUF Config: Using default configuration. Set window.__STUF_CONFIG__ for runtime configuration.",
+    );
+  });
+
+  it("caches the config after first call", () => {
+    const runtimeConfig: StufConfig = {
+      apiBaseUrl: "https://api.example.com",
+      keycloakUrl: "https://auth.example.com",
+      keycloakRealm: "production",
+      keycloakClientId: "prod-client",
+    };
+
+    window.__STUF_CONFIG__ = runtimeConfig;
+
+    const config1 = getConfig();
+    const config2 = getConfig();
+
+    // Should return the same object reference (cached)
+    expect(config1).toBe(config2);
+  });
+
+  it("does not log warning when runtime config is set", async () => {
+    const runtimeConfig: StufConfig = {
+      apiBaseUrl: "https://api.example.com",
+      keycloakUrl: "https://auth.example.com",
+      keycloakRealm: "production",
+      keycloakClientId: "prod-client",
+    };
+
+    window.__STUF_CONFIG__ = runtimeConfig;
+
+    // Need to re-import to clear the cache
+    const { getConfig: freshGetConfig } = await import("./config");
+
+    freshGetConfig();
+
+    expect(console.warn).not.toHaveBeenCalled();
+  });
+});

--- a/spa/src/config.ts
+++ b/spa/src/config.ts
@@ -2,5 +2,49 @@
  * Application configuration
  */
 
-export const API_BASE_URL =
-  process.env.REACT_APP_API_URL || "http://localhost:8000";
+// Extend the Window interface to include our runtime config
+declare global {
+  interface Window {
+    __STUF_CONFIG__?: StufConfig;
+  }
+}
+
+export interface StufConfig {
+  apiBaseUrl: string;
+  keycloakUrl: string;
+  keycloakRealm: string;
+  keycloakClientId: string;
+}
+
+const DEFAULTS: StufConfig = {
+  apiBaseUrl: "http://localhost:8000",
+  keycloakUrl: "http://localhost:8080",
+  keycloakRealm: "stuf",
+  keycloakClientId: "stuf-spa",
+};
+
+let configCache: StufConfig | null = null;
+
+/**
+ * Get the application configuration.
+ * Reads from window.__STUF_CONFIG__ (set by docker-entrypoint.sh at runtime).
+ * Falls back to defaults if not available (e.g., local development outside Docker).
+ */
+export function getConfig(): StufConfig {
+  if (configCache) {
+    return configCache;
+  }
+
+  if (typeof window !== "undefined" && window.__STUF_CONFIG__) {
+    configCache = window.__STUF_CONFIG__;
+    return configCache;
+  }
+
+  // Using defaults - log warning
+  console.warn(
+    "STUF Config: Using default configuration. Set window.__STUF_CONFIG__ for runtime configuration.",
+  );
+
+  configCache = DEFAULTS;
+  return configCache;
+}

--- a/spa/src/index.tsx
+++ b/spa/src/index.tsx
@@ -1,15 +1,17 @@
-import React from "react";
 import ReactDOM from "react-dom/client";
 import { AuthProvider } from "react-oidc-context";
 import App from "./App";
+import { getConfig } from "./config";
 import { ThemeProvider } from "./contexts/ThemeContext";
 import "./index.css";
 
-const authority = `${process.env.REACT_APP_KEYCLOAK_URL || "http://localhost:8080"}/realms/${process.env.REACT_APP_KEYCLOAK_REALM || "stuf"}`;
+const { keycloakUrl, keycloakRealm, keycloakClientId } = getConfig();
+
+const authority = `${keycloakUrl}/realms/${keycloakRealm}`;
 
 const oidcConfig = {
   authority,
-  client_id: process.env.REACT_APP_KEYCLOAK_CLIENT_ID || "stuf-spa",
+  client_id: keycloakClientId,
   redirect_uri: window.location.origin,
   post_logout_redirect_uri: window.location.origin,
   response_type: "code",

--- a/spa/src/services/api/apiClient.ts
+++ b/spa/src/services/api/apiClient.ts
@@ -1,18 +1,18 @@
-import type {
-  IApiClient,
-  AuthContext,
-  RequestOptions,
-} from "@/types/services/api";
-import { API_BASE_URL } from "@/config";
+import { getConfig } from "@/config";
 import {
   ApiError,
-  NotFoundError,
   ForbiddenError,
+  NetworkError,
+  NotFoundError,
+  ServerError,
   UnauthorizedError,
   ValidationError,
-  NetworkError,
-  ServerError,
 } from "@/errors/api";
+import type {
+  AuthContext,
+  IApiClient,
+  RequestOptions,
+} from "@/types/services/api";
 
 /**
  * HTTP client for making API requests
@@ -26,8 +26,9 @@ export class ApiClient implements IApiClient {
 
   async request(endpoint: string, options: RequestOptions = {}): Promise<any> {
     try {
+      const { apiBaseUrl } = getConfig();
       const token = this.auth?.user?.access_token;
-      const url = `${API_BASE_URL}${endpoint}`;
+      const url = `${apiBaseUrl}${endpoint}`;
 
       // Always include Authorization header if we have a token
       const headers: Record<string, string> = {

--- a/spa/vite.config.ts
+++ b/spa/vite.config.ts
@@ -1,23 +1,19 @@
-import { defineConfig } from "vite";
-import react from "@vitejs/plugin-react";
 import tailwindcss from "@tailwindcss/vite";
+import react from "@vitejs/plugin-react";
 import path from "path";
+import { defineConfig } from "vite";
 
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react(), tailwindcss()],
   server: {
     host: "0.0.0.0",
-    port: 3000,
+    port: 3000, // Default port (can be overridden via CLI in docker-entrypoint.sh)
     watch: {
       usePolling: true,
     },
     // Allow all origins for Docker networking
     cors: true,
-    // Disable host checking for containers
-    hmr: {
-      clientPort: 3000,
-    },
     // Allow Docker container hostnames
     allowedHosts: ["spa-e2e", "localhost", "127.0.0.1", "all"],
   },
@@ -28,9 +24,5 @@ export default defineConfig({
     alias: {
       "@": path.resolve(__dirname, "./src"),
     },
-  },
-  define: {
-    // Make process.env available in the browser for compatibility with existing code
-    "process.env": JSON.stringify(process.env),
   },
 });

--- a/tests/e2e-browser/docker-compose.e2e-browser.yml
+++ b/tests/e2e-browser/docker-compose.e2e-browser.yml
@@ -109,15 +109,12 @@ services:
       - "3100:3000" # Different port
     environment:
       # API configuration (internal Docker network URL)
-      - REACT_APP_API_URL=http://api-e2e:8000
+      - API_URL=http://api-e2e:8000
 
       # Keycloak configuration (internal Docker network URL)
-      - REACT_APP_KEYCLOAK_URL=http://keycloak-e2e:8080
-      - REACT_APP_KEYCLOAK_REALM=stuf
-      - REACT_APP_KEYCLOAK_CLIENT_ID=stuf-spa
-
-      # Development settings
-      - REACT_APP_NODE_ENV=development
+      - KEYCLOAK_URL=http://keycloak-e2e:8080
+      - KEYCLOAK_REALM=stuf
+      - KEYCLOAK_CLIENT_ID=stuf-spa
     depends_on:
       - api-e2e
     networks:


### PR DESCRIPTION
This PR adds runtime configuration support for the SPA, replacing `REACT_APP_*` environment variables with a `docker-entrypoint.sh` that injects configuration via `window.__STUF_CONFIG__` at container startup.

This enables the same Docker image to be deployed to different environments without rebuilding, which closes #66.

Just an FYI, I did consider adding environment-driven local development (reading from root .env when running npm run dev outside Docker), but deferred due to added complexity for an edge use case. For now, local non-Docker development uses hardcoded defaults. I’ve raised ticket #70 to track this.