### PR TITLE
build(spa): expose public folder to prod image

### DIFF
--- a/spa/Dockerfile
+++ b/spa/Dockerfile
@@ -47,6 +47,9 @@ COPY index.html ./
 # Copy source code
 COPY src/ ./src/
 
+# Copy public assets (icons, etc.)
+COPY public/ ./public/
+
 # Install dev dependencies needed for build
 RUN npm install vite @vitejs/plugin-react --save-dev
 


### PR DESCRIPTION
This PR fixes #71, where icons and other static assets from the `public/` directory were missing in production builds of the SPA. The problem occurred because the production stage of `spa/Dockerfile` did not copy the `public/` folder into the image before running the Vite build.