### PR TITLE
auth: use OIDC discovery and env-driven audience list

### DIFF
--- a/api/auth/middleware.py
+++ b/api/auth/middleware.py
@@ -1,6 +1,7 @@
 import json
 import logging
 import os
+import time
 from typing import Optional, Union
 
 import requests
@@ -10,48 +11,53 @@ from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from jose import jwk, jwt
 from jose.exceptions import ExpiredSignatureError, JWTClaimsError, JWTError
 
-# Keycloak configuration
-KEYCLOAK_URL = os.environ.get(
-    "KEYCLOAK_URL", "http://localhost:8080"
-)  # For internal API calls (JWKS, etc.)
-KEYCLOAK_ISSUER_URL = os.environ.get(
-    "KEYCLOAK_ISSUER_URL", "http://localhost:8080"
-)  # For JWT issuer validation
-KEYCLOAK_REALM = os.environ.get("KEYCLOAK_REALM", "stuf")
-KEYCLOAK_CLIENT_ID = os.environ.get("KEYCLOAK_CLIENT_ID", "stuf-api")
-KEYCLOAK_CLIENT_SECRET = os.environ.get("KEYCLOAK_CLIENT_SECRET", "some-secret-value")
-
-# Keycloak endpoints
-token_endpoint = f"{KEYCLOAK_URL}/realms/{KEYCLOAK_REALM}/protocol/openid-connect/token"
-userinfo_endpoint = (
-    f"{KEYCLOAK_URL}/realms/{KEYCLOAK_REALM}/protocol/openid-connect/userinfo"
+# OIDC_ISSUER_URL: the issuer URL as it appears in tokens. Used to validate the
+# `iss` claim and (when OIDC_BASE_URL is not set) to fetch the discovery document.
+OIDC_ISSUER_URL = os.environ.get(
+    "OIDC_ISSUER_URL", "http://localhost:8080/realms/stuf"
 )
-introspect_endpoint = (
-    f"{KEYCLOAK_URL}/realms/{KEYCLOAK_REALM}/protocol/openid-connect/token/introspect"
+
+# OIDC_BASE_URL: optional override for the base URL used to fetch the discovery
+# document and JWKS. Set this to the container-internal hostname when the issuer
+# URL visible to clients (OIDC_ISSUER_URL) differs from the URL reachable by the
+# API process (e.g. docker-compose where keycloak is on an internal network).
+# Defaults to OIDC_ISSUER_URL when not set.
+_OIDC_BASE_URL = os.environ.get("OIDC_BASE_URL", OIDC_ISSUER_URL)
+
+OIDC_VALID_AUDIENCES = set(
+    a.strip()
+    for a in os.environ.get("OIDC_VALID_AUDIENCES", "stuf-api,stuf-spa").split(",")
+    if a.strip()
 )
-jwks_uri = f"{KEYCLOAK_URL}/realms/{KEYCLOAK_REALM}/protocol/openid-connect/certs"
 
-
-# Bearer token scheme for both user and service account validation
-# Using auto_error=False to handle authentication errors manually
 bearer_scheme = HTTPBearer(auto_error=False)
 
+_discovery_doc: dict = {}
+_jwks_cache: dict = {"keys": [], "fetched_at": 0.0}
+_JWKS_TTL = 300  # seconds
 
-def get_keycloak_public_keys():
-    """Fetch Keycloak public keys for JWT verification"""
-    logger = logging.getLogger(__name__)
 
-    try:
-        jwks_response = requests.get(jwks_uri, timeout=10)
-        if jwks_response.status_code != 200:
-            logger.error(f"Failed to fetch JWKS: {jwks_response.status_code}")
-            return None
+def _fetch_discovery() -> dict:
+    """Fetch and cache the OIDC discovery document."""
+    global _discovery_doc
+    if not _discovery_doc:
+        url = f"{_OIDC_BASE_URL}/.well-known/openid-configuration"
+        resp = requests.get(url, timeout=10)
+        resp.raise_for_status()
+        _discovery_doc = resp.json()
+    return _discovery_doc
 
-        jwks = jwks_response.json()
-        return jwks
-    except Exception as e:
-        logger.error(f"Exception fetching JWKS: {e}")
-        return None
+
+def _get_jwks(force_refresh: bool = False) -> list:
+    """Return cached JWKS keys, refreshing from the provider when stale or forced."""
+    global _jwks_cache
+    now = time.monotonic()
+    if force_refresh or now - _jwks_cache["fetched_at"] > _JWKS_TTL:
+        discovery = _fetch_discovery()
+        resp = requests.get(discovery["jwks_uri"], timeout=10)
+        resp.raise_for_status()
+        _jwks_cache = {"keys": resp.json().get("keys", []), "fetched_at": now}
+    return _jwks_cache["keys"]
 
 
 def verify_jwt_token(token: str):
@@ -61,36 +67,30 @@ def verify_jwt_token(token: str):
     logger.info(f"Verifying JWT token (first 50 chars): {token[:50]}...")
 
     try:
-        # Get Keycloak public keys
-        jwks = get_keycloak_public_keys()
-        if not jwks:
-            logger.error("Could not fetch Keycloak public keys")
-            return None
-
-        # Decode token header to get key ID
         header = jwt.get_unverified_header(token)
         kid = header.get("kid")
         if not kid:
             logger.error("JWT token missing key ID")
             return None
 
-        # Find the matching public key
+        # Try the cached JWKS first; on a cache miss force one refresh to handle
+        # key rotation before giving up.
         public_key = None
-        for key in jwks.get("keys", []):
-            if key.get("kid") == kid:
-                public_key = jwk.construct(key)
+        for force in (False, True):
+            keys = _get_jwks(force_refresh=force)
+            for key in keys:
+                if key.get("kid") == kid:
+                    public_key = jwk.construct(key)
+                    break
+            if public_key or force:
                 break
 
         if not public_key:
             logger.error(f"Could not find public key for kid: {kid}")
             return None
 
-        # Verify and decode JWT with signature validation
-        expected_issuer = f"{KEYCLOAK_ISSUER_URL}/realms/{KEYCLOAK_REALM}"
-
-        # JWT validation options - disable audience verification to handle manually
         options = {
-            "verify_aud": False,  # Handle audience validation manually
+            "verify_aud": False,  # Handle audience validation manually below
             "verify_iss": True,
             "verify_exp": True,
         }
@@ -98,18 +98,16 @@ def verify_jwt_token(token: str):
         token_payload = jwt.decode(
             token,
             public_key,
-            algorithms=["RS256"],  # Keycloak uses RS256
+            algorithms=["RS256"],
             options=options,
-            issuer=expected_issuer,
+            issuer=OIDC_ISSUER_URL,
         )
 
-        # Manually validate audience since jose is strict about format
         token_aud = token_payload.get("aud", [])
         if isinstance(token_aud, str):
             token_aud = [token_aud]
 
-        valid_audiences = {"stuf-api", "stuf-spa"}
-        if not any(aud in valid_audiences for aud in token_aud):
+        if not any(aud in OIDC_VALID_AUDIENCES for aud in token_aud):
             logger.error(f"Invalid audience in token: {token_aud}")
             return None
 

--- a/api/tests/e2e/test_auth_e2e.py
+++ b/api/tests/e2e/test_auth_e2e.py
@@ -2,8 +2,8 @@ import pytest
 from fastapi.security import HTTPBearer
 
 from api.auth.middleware import (
-    KEYCLOAK_REALM,
-    KEYCLOAK_URL,
+    OIDC_ISSUER_URL,
+    OIDC_VALID_AUDIENCES,
     bearer_scheme,
     verify_jwt_token,
 )
@@ -19,9 +19,9 @@ class TestAuthenticationE2E:
         # Verify bearer scheme type
         assert isinstance(bearer_scheme, HTTPBearer)
 
-        # Verify Keycloak configuration is present
-        assert KEYCLOAK_URL is not None
-        assert KEYCLOAK_REALM is not None
+        # Verify OIDC configuration is present
+        assert OIDC_ISSUER_URL is not None
+        assert len(OIDC_VALID_AUDIENCES) > 0
 
     def test_token_validation_with_real_keycloak(self, real_keycloak_token):
         """Test token validation against real Keycloak instance"""

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -48,11 +48,9 @@ services:
     ports:
       - "${API_PORT:-8000}:8000"
     environment:
-      - KEYCLOAK_URL=http://keycloak:8080
-      - KEYCLOAK_ISSUER_URL=http://localhost:8080
-      - KEYCLOAK_REALM=${KEYCLOAK_REALM:-stuf}
-      - KEYCLOAK_CLIENT_ID=${KEYCLOAK_API_CLIENT_ID:-stuf-api}
-      - KEYCLOAK_CLIENT_SECRET=${KEYCLOAK_API_CLIENT_SECRET:-some-secret-value}
+      - OIDC_ISSUER_URL=http://localhost:8080/realms/${KEYCLOAK_REALM:-stuf}
+      - OIDC_BASE_URL=http://keycloak:8080/realms/${KEYCLOAK_REALM:-stuf}
+      - OIDC_VALID_AUDIENCES=${OIDC_VALID_AUDIENCES:-stuf-api,stuf-spa}
       - MINIO_ENDPOINT=minio:9000
       - MINIO_ROOT_USER=${MINIO_ROOT_USER:-minioadmin}
       - MINIO_ROOT_PASSWORD=${MINIO_ROOT_PASSWORD:-minioadmin}

--- a/spa/docker-entrypoint.sh
+++ b/spa/docker-entrypoint.sh
@@ -12,23 +12,32 @@ if [ -z "$API_URL" ]; then
   echo "WARNING: API_URL not set, using default: $DEFAULT_API_BASE_URL"
 fi
 
-if [ -z "$KEYCLOAK_URL" ]; then
+if [ -z "$KEYCLOAK_URL" ] && [ -z "$OIDC_AUTHORITY" ]; then
   echo "WARNING: KEYCLOAK_URL not set, using default: $DEFAULT_KEYCLOAK_URL"
 fi
 
-if [ -z "$KEYCLOAK_REALM" ]; then
+if [ -z "$KEYCLOAK_REALM" ] && [ -z "$OIDC_AUTHORITY" ]; then
   echo "WARNING: KEYCLOAK_REALM not set, using default: $DEFAULT_KEYCLOAK_REALM"
 fi
 
-if [ -z "$KEYCLOAK_CLIENT_ID" ]; then
+if [ -z "$KEYCLOAK_CLIENT_ID" ] && [ -z "$OIDC_CLIENT_ID" ]; then
   echo "WARNING: KEYCLOAK_CLIENT_ID not set, using default: $DEFAULT_KEYCLOAK_CLIENT_ID"
 fi
 
 # Get values from environment or use defaults
 API_BASE_URL="${API_URL:-$DEFAULT_API_BASE_URL}"
-KEYCLOAK_URL="${KEYCLOAK_URL:-$DEFAULT_KEYCLOAK_URL}"
-KEYCLOAK_REALM="${KEYCLOAK_REALM:-$DEFAULT_KEYCLOAK_REALM}"
-KEYCLOAK_CLIENT_ID="${KEYCLOAK_CLIENT_ID:-$DEFAULT_KEYCLOAK_CLIENT_ID}"
+
+# OIDC_AUTHORITY may be set directly (provider-agnostic) or computed from
+# KEYCLOAK_URL + KEYCLOAK_REALM for backwards-compatible Keycloak deployments.
+if [ -n "$OIDC_AUTHORITY" ]; then
+  COMPUTED_OIDC_AUTHORITY="$OIDC_AUTHORITY"
+else
+  _KC_URL="${KEYCLOAK_URL:-$DEFAULT_KEYCLOAK_URL}"
+  _KC_REALM="${KEYCLOAK_REALM:-$DEFAULT_KEYCLOAK_REALM}"
+  COMPUTED_OIDC_AUTHORITY="${_KC_URL}/realms/${_KC_REALM}"
+fi
+
+COMPUTED_OIDC_CLIENT_ID="${OIDC_CLIENT_ID:-${KEYCLOAK_CLIENT_ID:-$DEFAULT_KEYCLOAK_CLIENT_ID}}"
 
 # Determine the mode (dev or prod) - default to prod
 MODE="${1:-prod}"
@@ -49,17 +58,15 @@ fi
 cat > "$CONFIG_PATH" <<EOF
 window.__STUF_CONFIG__ = {
   apiBaseUrl: "$API_BASE_URL",
-  keycloakUrl: "$KEYCLOAK_URL",
-  keycloakRealm: "$KEYCLOAK_REALM",
-  keycloakClientId: "$KEYCLOAK_CLIENT_ID"
+  oidcAuthority: "$COMPUTED_OIDC_AUTHORITY",
+  oidcClientId: "$COMPUTED_OIDC_CLIENT_ID"
 };
 EOF
 
 echo "Generated runtime configuration at $CONFIG_PATH:"
 echo "  API Base URL: $API_BASE_URL"
-echo "  Keycloak URL: $KEYCLOAK_URL"
-echo "  Keycloak Realm: $KEYCLOAK_REALM"
-echo "  Keycloak Client ID: $KEYCLOAK_CLIENT_ID"
+echo "  OIDC Authority: $COMPUTED_OIDC_AUTHORITY"
+echo "  OIDC Client ID: $COMPUTED_OIDC_CLIENT_ID"
 echo "  Port: $SPA_PORT"
 
 # Start the appropriate server based on mode

--- a/spa/src/config.ts
+++ b/spa/src/config.ts
@@ -11,16 +11,14 @@ declare global {
 
 export interface StufConfig {
   apiBaseUrl: string;
-  keycloakUrl: string;
-  keycloakRealm: string;
-  keycloakClientId: string;
+  oidcAuthority: string;
+  oidcClientId: string;
 }
 
 const DEFAULTS: StufConfig = {
   apiBaseUrl: "http://localhost:8000",
-  keycloakUrl: "http://localhost:8080",
-  keycloakRealm: "stuf",
-  keycloakClientId: "stuf-spa",
+  oidcAuthority: "http://localhost:8080/realms/stuf",
+  oidcClientId: "stuf-spa",
 };
 
 let configCache: StufConfig | null = null;

--- a/spa/src/index.tsx
+++ b/spa/src/index.tsx
@@ -5,13 +5,11 @@ import { getConfig } from "./config";
 import { ThemeProvider } from "./contexts/ThemeContext";
 import "./index.css";
 
-const { keycloakUrl, keycloakRealm, keycloakClientId } = getConfig();
-
-const authority = `${keycloakUrl}/realms/${keycloakRealm}`;
+const { oidcAuthority, oidcClientId } = getConfig();
 
 const oidcConfig = {
-  authority,
-  client_id: keycloakClientId,
+  authority: oidcAuthority,
+  client_id: oidcClientId,
   redirect_uri: window.location.origin,
   post_logout_redirect_uri: window.location.origin,
   response_type: "code",

--- a/tests/e2e-browser/docker-compose.e2e-browser.yml
+++ b/tests/e2e-browser/docker-compose.e2e-browser.yml
@@ -64,12 +64,9 @@ services:
     ports:
       - "8100:8000" # Different port
     environment:
-      # Keycloak configuration (internal network)
-      - KEYCLOAK_URL=http://keycloak-e2e:8080
-      - KEYCLOAK_ISSUER_URL=http://keycloak-e2e:8080 # Internal Docker network URL
-      - KEYCLOAK_REALM=stuf
-      - KEYCLOAK_CLIENT_ID=stuf-api
-      - KEYCLOAK_CLIENT_SECRET=test-secret-e2e
+      # OIDC configuration (internal network; issuer and fetch URL are the same in e2e)
+      - OIDC_ISSUER_URL=http://keycloak-e2e:8080/realms/stuf
+      - OIDC_VALID_AUDIENCES=stuf-api,stuf-spa
 
       # MinIO configuration (internal network)
       - MINIO_ENDPOINT=minio-e2e:9000
@@ -143,10 +140,10 @@ services:
       - API_URL=http://api-e2e:8000
       - KEYCLOAK_URL=http://keycloak-e2e:8080
       - MINIO_URL=http://minio-e2e:9000
-      # API E2E tests need these for proper JWT validation
-      - KEYCLOAK_ISSUER_URL=http://keycloak-e2e:8080
+      # API E2E tests: OIDC vars for middleware, KEYCLOAK_* vars for token fixtures
+      - OIDC_ISSUER_URL=http://keycloak-e2e:8080/realms/stuf
+      - OIDC_VALID_AUDIENCES=stuf-api,stuf-spa
       - KEYCLOAK_REALM=stuf
-      - KEYCLOAK_CLIENT_ID=stuf-api
       # MinIO configuration for API E2E tests
       - MINIO_ENDPOINT=minio-e2e:9000
       - MINIO_ROOT_USER=minioadmin


### PR DESCRIPTION
Part of #85 — steps 1 and 2 of the implementation sequence in `tasks/0001`.

## What changes

### Step 1: OIDC discovery and env-driven audience list (`api/auth/middleware.py`)

Replaces hand-built Keycloak URL templates with OIDC discovery, and makes the audience allow-list configurable:

- **OIDC discovery**: A single `OIDC_ISSUER_URL` env var (the issuer as it appears in tokens) replaces `KEYCLOAK_URL` + `KEYCLOAK_ISSUER_URL` + `KEYCLOAK_REALM`. The `jwks_uri` is read from the provider's `.well-known/openid-configuration` instead of being templated by hand.
- **`OIDC_BASE_URL`** (optional): When the API process needs to reach the OIDC provider via an internal hostname (e.g. `keycloak:8080` inside docker-compose) while tokens carry a different external issuer URL, set this to the internal base URL. Defaults to `OIDC_ISSUER_URL` when not set.
- **JWKS caching**: Keys are cached for 5 minutes and force-refreshed on a key-ID miss (handles rotation), instead of one HTTP call per request.
- **`OIDC_VALID_AUDIENCES`**: Comma-separated env var replaces the hard-coded `{"stuf-api","stuf-spa"}` set.
- **Removed dead code**: `token_endpoint`, `userinfo_endpoint`, `introspect_endpoint`, `KEYCLOAK_CLIENT_ID`, `KEYCLOAK_CLIENT_SECRET` were defined but never used.

`docker-compose.yml` and `tests/e2e-browser/docker-compose.e2e-browser.yml` updated to supply the new env vars.

### Step 2: SPA authority construction moved to `docker-entrypoint.sh`

Replaces the `keycloakUrl/keycloakRealm/keycloakClientId` triple in `window.__STUF_CONFIG__` with `oidcAuthority` + `oidcClientId`. The authority URL is now assembled in the entrypoint (shell) rather than in `index.tsx` (JS), so the SPA has no knowledge of provider-specific URL shapes.

Backwards-compatible: the entrypoint still reads `KEYCLOAK_URL` and `KEYCLOAK_REALM` to compute the authority when `OIDC_AUTHORITY` is not set directly.

## No behaviour change

Keycloak is still the only provider in use. All unit, integration, and E2E tests pass.