### PR TITLE
compose: stand up Zitadel stack with provisioning (steps 3–4)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,6 @@ name: CI Tests
 
 on:
   pull_request:
-    branches: [master]
   push:
     branches: [master]
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -90,8 +90,14 @@ services:
       timeout: 3s
       retries: 5
 
-  # Makes the bootstrap volume world-writable so the Zitadel container (user
-  # "zitadel", non-root) can write the machine key file on first init.
+  # Makes the bootstrap volume world-writable/readable. Three containers with
+  # different users share it: zitadel (writes the machine key), zitadel-init
+  # root (writes login-token + generated.env), and zitadel-login nextjs user
+  # (reads login-token). A targeted chown is not feasible because busybox has
+  # no shared /etc/passwd with the other images, so their usernames ("zitadel",
+  # "nextjs") are unknown here — only hard-coding numeric UIDs would work, and
+  # those are internal image implementation details. World-writable is
+  # acceptable for a dev-only volume that holds no production credentials.
   zitadel-bootstrap-init:
     image: busybox:1.37
     profiles:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -167,11 +167,12 @@ services:
     network_mode: host
     environment:
       ZITADEL_DOMAIN: http://localhost:${ZITADEL_PORT:-8080}
-      ZITADEL_ADMIN_EMAIL: ${ZITADEL_ADMIN_EMAIL:-admin@example.com}
       MACHINE_KEY_PATH: /bootstrap/zitadel-admin-sa.json
       BOOTSTRAP_DIR: /bootstrap
+      FIXTURE_PATH: /fixtures/dev/instance.yaml
     volumes:
       - zitadel-bootstrap:/bootstrap
+      - ./docker/zitadel-init:/fixtures:ro
     depends_on:
       zitadel:
         condition: service_healthy

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -90,6 +90,17 @@ services:
       timeout: 3s
       retries: 5
 
+  # Makes the bootstrap volume world-writable so the Zitadel container (user
+  # "zitadel", non-root) can write the machine key file on first init.
+  zitadel-bootstrap-init:
+    image: busybox:1.37
+    profiles:
+      - zitadel
+    command: ["chmod", "777", "/bootstrap"]
+    volumes:
+      - zitadel-bootstrap:/bootstrap
+    restart: "no"
+
   zitadel:
     image: ghcr.io/zitadel/zitadel:v4.14.0
     profiles:
@@ -117,11 +128,20 @@ services:
       ZITADEL_FIRSTINSTANCE_ORG_HUMAN_EMAIL_VERIFIED: "true"
       ZITADEL_FIRSTINSTANCE_ORG_HUMAN_FIRSTNAME: Admin
       ZITADEL_FIRSTINSTANCE_ORG_HUMAN_LASTNAME: User
+      # Machine user for zitadel-init provisioning script; key written to bootstrap volume
+      ZITADEL_FIRSTINSTANCE_ORG_MACHINE_MACHINE_USERNAME: zitadel-admin-sa
+      ZITADEL_FIRSTINSTANCE_ORG_MACHINE_MACHINE_NAME: Zitadel Admin SA
+      ZITADEL_FIRSTINSTANCE_ORG_MACHINE_MACHINEKEY_TYPE: 1
+      ZITADEL_FIRSTINSTANCE_MACHINEKEYPATH: /bootstrap/zitadel-admin-sa.json
+    volumes:
+      - zitadel-bootstrap:/bootstrap
     ports:
       - "${ZITADEL_PORT:-8080}:8080"
     depends_on:
       zitadel-postgres:
         condition: service_healthy
+      zitadel-bootstrap-init:
+        condition: service_completed_successfully
     healthcheck:
       test: ["CMD", "/app/zitadel", "ready"]
       interval: 10s
@@ -129,18 +149,50 @@ services:
       retries: 10
       start_period: 60s
 
+  zitadel-init:
+    build:
+      context: ./docker/zitadel-init
+      dockerfile: Dockerfile
+    profiles:
+      - zitadel
+    # Use host networking so the script calls http://localhost:8080 — Zitadel
+    # validates the Host header against ZITADEL_EXTERNALDOMAIN (localhost), so
+    # requests from inside Docker on the internal hostname 'zitadel' get 404s.
+    network_mode: host
+    environment:
+      ZITADEL_DOMAIN: http://localhost:${ZITADEL_PORT:-8080}
+      ZITADEL_ADMIN_EMAIL: ${ZITADEL_ADMIN_EMAIL:-admin@example.com}
+      MACHINE_KEY_PATH: /bootstrap/zitadel-admin-sa.json
+      BOOTSTRAP_DIR: /bootstrap
+    volumes:
+      - zitadel-bootstrap:/bootstrap
+    depends_on:
+      zitadel:
+        condition: service_healthy
+    restart: "no"
+
   zitadel-login:
     image: ghcr.io/zitadel/zitadel-login:v4.14.0
     profiles:
       - zitadel
+    # Use host networking (same reason as zitadel-init): Zitadel validates the
+    # Host header against ZITADEL_EXTERNALDOMAIN (localhost), so requests from
+    # inside Docker on 'zitadel:8080' get "Instance not found" errors.
+    # With host networking, ZITADEL_API_URL uses localhost:8080 directly.
+    # PORT tells the Next.js server which host port to bind on.
+    network_mode: host
+    # Read the PAT written by zitadel-init from the shared volume and export
+    # it as ZITADEL_SERVICE_USER_TOKEN before starting the login UI server.
+    entrypoint: ["/bin/sh", "-c", "export ZITADEL_SERVICE_USER_TOKEN=$(cat /bootstrap/login-token) && exec /app/entrypoint.sh node apps/login/server.js"]
     environment:
-      ZITADEL_API_URL: http://zitadel:8080
-      # ZITADEL_SERVICE_USER_TOKEN is set by the zitadel-init provisioning step (step 4)
-    ports:
-      - "${ZITADEL_LOGIN_PORT:-8090}:3000"
+      ZITADEL_API_URL: http://localhost:${ZITADEL_PORT:-8080}
+      PORT: ${ZITADEL_LOGIN_PORT:-8090}
+    volumes:
+      - zitadel-bootstrap:/bootstrap:ro
     depends_on:
-      zitadel:
-        condition: service_healthy
+      zitadel-init:
+        condition: service_completed_successfully
 
 volumes:
   minio_data:
+  zitadel-bootstrap:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,7 @@
 services:
   keycloak:
+    profiles:
+      - keycloak
     build:
       context: ./docker/keycloak
       dockerfile: Dockerfile
@@ -58,8 +60,6 @@ services:
     depends_on:
       minio:
         condition: service_healthy
-      keycloak:
-        condition: service_started
 
   spa:
     build:
@@ -75,6 +75,72 @@ services:
       - KEYCLOAK_CLIENT_ID=${KEYCLOAK_SPA_CLIENT_ID:-stuf-spa}
     depends_on:
       - api
+
+  zitadel-postgres:
+    image: postgres:17
+    profiles:
+      - zitadel
+    environment:
+      POSTGRES_USER: ${ZITADEL_DB_USER:-zitadel}
+      POSTGRES_PASSWORD: ${ZITADEL_DB_PASSWORD:-zitadel}
+      POSTGRES_DB: ${ZITADEL_DB_NAME:-zitadel}
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${ZITADEL_DB_USER:-zitadel} -d ${ZITADEL_DB_NAME:-zitadel}"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
+
+  zitadel:
+    image: ghcr.io/zitadel/zitadel:v4.14.0
+    profiles:
+      - zitadel
+    command: start-from-init --masterkey "${ZITADEL_MASTERKEY:-MasterkeyNeedsToHave32Characters}" --tlsMode disabled
+    environment:
+      ZITADEL_DATABASE_POSTGRES_HOST: zitadel-postgres
+      ZITADEL_DATABASE_POSTGRES_PORT: 5432
+      ZITADEL_DATABASE_POSTGRES_DATABASE: ${ZITADEL_DB_NAME:-zitadel}
+      ZITADEL_DATABASE_POSTGRES_USER_USERNAME: ${ZITADEL_DB_USER:-zitadel}
+      ZITADEL_DATABASE_POSTGRES_USER_PASSWORD: ${ZITADEL_DB_PASSWORD:-zitadel}
+      ZITADEL_DATABASE_POSTGRES_USER_SSL_MODE: disable
+      ZITADEL_DATABASE_POSTGRES_ADMIN_USERNAME: ${ZITADEL_DB_USER:-zitadel}
+      ZITADEL_DATABASE_POSTGRES_ADMIN_PASSWORD: ${ZITADEL_DB_PASSWORD:-zitadel}
+      ZITADEL_DATABASE_POSTGRES_ADMIN_SSL_MODE: disable
+      ZITADEL_TLS_ENABLED: "false"
+      ZITADEL_EXTERNALSECURE: "false"
+      ZITADEL_EXTERNALPORT: ${ZITADEL_PORT:-8080}
+      ZITADEL_EXTERNALDOMAIN: localhost
+      ZITADEL_DEFAULTINSTANCE_FEATURES_LOGINV2_BASEURI: http://localhost:${ZITADEL_LOGIN_PORT:-8090}/ui/v2/login
+      ZITADEL_FIRSTINSTANCE_ORG_NAME: STUF
+      ZITADEL_FIRSTINSTANCE_ORG_HUMAN_USERNAME: ${ZITADEL_ADMIN_USERNAME:-admin}
+      ZITADEL_FIRSTINSTANCE_ORG_HUMAN_PASSWORD: ${ZITADEL_ADMIN_PASSWORD:-Password1!}
+      ZITADEL_FIRSTINSTANCE_ORG_HUMAN_EMAIL_ADDRESS: ${ZITADEL_ADMIN_EMAIL:-admin@example.com}
+      ZITADEL_FIRSTINSTANCE_ORG_HUMAN_EMAIL_VERIFIED: "true"
+      ZITADEL_FIRSTINSTANCE_ORG_HUMAN_FIRSTNAME: Admin
+      ZITADEL_FIRSTINSTANCE_ORG_HUMAN_LASTNAME: User
+    ports:
+      - "${ZITADEL_PORT:-8080}:8080"
+    depends_on:
+      zitadel-postgres:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "/app/zitadel", "ready"]
+      interval: 10s
+      timeout: 3s
+      retries: 10
+      start_period: 60s
+
+  zitadel-login:
+    image: ghcr.io/zitadel/zitadel-login:v4.14.0
+    profiles:
+      - zitadel
+    environment:
+      ZITADEL_API_URL: http://zitadel:8080
+      # ZITADEL_SERVICE_USER_TOKEN is set by the zitadel-init provisioning step (step 4)
+    ports:
+      - "${ZITADEL_LOGIN_PORT:-8090}:3000"
+    depends_on:
+      zitadel:
+        condition: service_healthy
 
 volumes:
   minio_data:

--- a/docker/zitadel-init/Dockerfile
+++ b/docker/zitadel-init/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.12-slim
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+COPY provision.py .
+CMD ["python", "-u", "provision.py"]

--- a/docker/zitadel-init/dev/instance.yaml
+++ b/docker/zitadel-init/dev/instance.yaml
@@ -1,0 +1,121 @@
+project:
+  name: stuf
+  roles:
+    - key: admin
+      displayName: Administrator
+    - key: trust-architect
+      displayName: Trust Architect
+    - key: project-participant
+      displayName: Project Participant
+    - key: collection-test
+      displayName: Collection Test
+    - key: service
+      displayName: Service Account
+
+apps:
+  spa:
+    name: stuf-spa
+    redirectUris:
+      - http://localhost:3000
+      - http://localhost:3100
+      - http://spa-e2e:3000
+    postLogoutRedirectUris:
+      - http://localhost:3000
+      - http://localhost:3100
+      - http://spa-e2e:3000
+  api:
+    name: stuf-api
+
+# Users with existing: true are created by ZITADEL_FIRSTINSTANCE_* env vars.
+# The script looks them up by email and applies roles + collections metadata
+# without creating or changing their password.
+human_users:
+  - existing: true
+    email: admin@example.com
+    roles: [admin]
+    collections:
+      test: [read, write, delete]
+      restricted: [read, write, delete]
+      shared: [read, write, delete]
+
+  - username: testuser
+    firstName: Test
+    lastName: User
+    email: testuser@example.com
+    password: password
+    roles: [project-participant]
+    collections:
+      test: [read, write, delete]
+      collection-1-docs: [read, write]
+      collection-2-contracts: [read]
+      collection-3-cat-pics: [read, write, delete]
+
+  - username: test-admin
+    firstName: Test
+    lastName: Admin
+    email: admin@test.example.com
+    password: test-password
+    roles: [admin]
+    collections:
+      test: [read, write, delete]
+      restricted: [read, write, delete]
+      shared: [read, write, delete]
+
+  - username: test-trust-architect
+    firstName: Test
+    lastName: Architect
+    email: ta@test.example.com
+    password: test-password
+    roles: [trust-architect]
+    collections:
+      test: [read, write, delete]
+      restricted: [read, write, delete]
+      shared: [read, write, delete]
+
+  - username: test-user-full
+    firstName: Test
+    lastName: FullUser
+    email: full@test.example.com
+    password: test-password
+    roles: [project-participant]
+    collections:
+      test: [read, write]
+      restricted: [read, write]
+      shared: [read, write]
+
+  - username: test-user-limited
+    firstName: Test
+    lastName: LimitedUser
+    email: limited@test.example.com
+    password: test-password
+    roles: [project-participant]
+    collections:
+      test: [read, write]
+
+  - username: test-user-shared
+    firstName: Test
+    lastName: SharedUser
+    email: shared@test.example.com
+    password: test-password
+    roles: [project-participant]
+    collections:
+      shared: [read, write]
+
+  - username: test-user-inactive
+    firstName: Test
+    lastName: InactiveUser
+    email: inactive@test.example.com
+    password: test-password
+    roles: [project-participant]
+    collections:
+      test: [read, write]
+    disabled: true
+
+machine_users:
+  - username: backup-service
+    name: Backup Service
+    description: Service account for backup operations
+    roles: [service]
+    collections:
+      test: [read]
+      shared: [read]

--- a/docker/zitadel-init/provision.py
+++ b/docker/zitadel-init/provision.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python3
 """
 Zitadel provisioning script for STUF development environment.
-Mirrors the content of docker/keycloak/data/import/realm-export.json.
+Reads instance fixture from FIXTURE_PATH (default: /fixtures/dev/instance.yaml)
+and mirrors it into Zitadel via the Management API.
 
-Run order: after Zitadel is healthy, before api/spa/zitadel-login start.
 Writes /bootstrap/login-token (PAT for zitadel-login) and
 /bootstrap/generated.env (generated client IDs for step 5 wiring).
 """
@@ -18,13 +18,14 @@ from datetime import datetime, timezone, timedelta
 
 import httpx
 import jwt
+import yaml
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.backends import default_backend
 
 ZITADEL_DOMAIN = os.environ.get("ZITADEL_DOMAIN", "http://localhost:8080")
 MACHINE_KEY_PATH = os.environ.get("MACHINE_KEY_PATH", "/bootstrap/zitadel-admin-sa.json")
 BOOTSTRAP_DIR = os.environ.get("BOOTSTRAP_DIR", "/bootstrap")
-ZITADEL_ADMIN_EMAIL = os.environ.get("ZITADEL_ADMIN_EMAIL", "admin@example.com")
+FIXTURE_PATH = os.environ.get("FIXTURE_PATH", "/fixtures/dev/instance.yaml")
 
 # Injected into every access token via the preAccessTokenCreation trigger.
 # - preferred_username: not in Zitadel JWT access tokens by default; mirrors
@@ -48,72 +49,10 @@ function preAccessTokenCreation(ctx, api) {
 }
 """
 
-HUMAN_USERS = [
-    {
-        "username": "testuser",
-        "firstName": "Test",
-        "lastName": "User",
-        "email": "testuser@example.com",
-        "password": "password",
-        "roles": ["project-participant"],
-        "collections": '{"test":["read","write","delete"],"collection-1-docs":["read","write"],"collection-2-contracts":["read"],"collection-3-cat-pics":["read","write","delete"]}',
-    },
-    {
-        "username": "test-admin",
-        "firstName": "Test",
-        "lastName": "Admin",
-        "email": "admin@test.example.com",
-        "password": "test-password",
-        "roles": ["admin"],
-        "collections": '{"test":["read","write","delete"],"restricted":["read","write","delete"],"shared":["read","write","delete"]}',
-    },
-    {
-        "username": "test-trust-architect",
-        "firstName": "Test",
-        "lastName": "Architect",
-        "email": "ta@test.example.com",
-        "password": "test-password",
-        "roles": ["trust-architect"],
-        "collections": '{"test":["read","write","delete"],"restricted":["read","write","delete"],"shared":["read","write","delete"]}',
-    },
-    {
-        "username": "test-user-full",
-        "firstName": "Test",
-        "lastName": "FullUser",
-        "email": "full@test.example.com",
-        "password": "test-password",
-        "roles": ["project-participant"],
-        "collections": '{"test":["read","write"],"restricted":["read","write"],"shared":["read","write"]}',
-    },
-    {
-        "username": "test-user-limited",
-        "firstName": "Test",
-        "lastName": "LimitedUser",
-        "email": "limited@test.example.com",
-        "password": "test-password",
-        "roles": ["project-participant"],
-        "collections": '{"test":["read","write"]}',
-    },
-    {
-        "username": "test-user-shared",
-        "firstName": "Test",
-        "lastName": "SharedUser",
-        "email": "shared@test.example.com",
-        "password": "test-password",
-        "roles": ["project-participant"],
-        "collections": '{"shared":["read","write"]}',
-    },
-    {
-        "username": "test-user-inactive",
-        "firstName": "Test",
-        "lastName": "InactiveUser",
-        "email": "inactive@test.example.com",
-        "password": "test-password",
-        "roles": ["project-participant"],
-        "collections": '{"test":["read","write"]}',
-        "disabled": True,
-    },
-]
+
+def load_fixture():
+    with open(FIXTURE_PATH) as f:
+        return yaml.safe_load(f)
 
 
 def wait_for_machine_key(path, timeout=120):
@@ -132,7 +71,7 @@ def wait_for_machine_key(path, timeout=120):
 
 
 def get_issuer_url():
-    for attempt in range(30):
+    for _ in range(30):
         try:
             resp = httpx.get(f"{ZITADEL_DOMAIN}/.well-known/openid-configuration", timeout=5)
             resp.raise_for_status()
@@ -145,14 +84,9 @@ def get_issuer_url():
 def create_jwt_assertion(key_data, issuer_url):
     user_id = key_data["userId"]
     key_id = key_data["keyId"]
-    private_key_pem = key_data["key"]
-
     private_key = serialization.load_pem_private_key(
-        private_key_pem.encode(),
-        password=None,
-        backend=default_backend(),
+        key_data["key"].encode(), password=None, backend=default_backend()
     )
-
     now = datetime.now(timezone.utc)
     payload = {
         "iss": user_id,
@@ -162,7 +96,6 @@ def create_jwt_assertion(key_data, issuer_url):
         "exp": int((now + timedelta(minutes=5)).timestamp()),
         "jti": str(uuid.uuid4()),
     }
-
     return jwt.encode(payload, private_key, algorithm="RS256", headers={"kid": key_id})
 
 
@@ -191,12 +124,17 @@ def api(client, method, path, **kwargs):
     return resp.json() if resp.content else {}
 
 
-def set_user_metadata(client, user_id, key, value_str):
-    encoded = base64.b64encode(value_str.encode()).decode()
-    api(client, "post", f"/management/v1/users/{user_id}/metadata/{key}", json={"value": encoded})
+def set_collections_metadata(client, user_id, collections):
+    """Serialize collections dict to JSON, base64-encode, and store as metadata."""
+    encoded = base64.b64encode(json.dumps(collections).encode()).decode()
+    api(client, "post", f"/management/v1/users/{user_id}/metadata/collections",
+        json={"value": encoded})
 
 
 def main():
+    print(f"Loading fixture from {FIXTURE_PATH} ...")
+    fixture = load_fixture()
+
     print(f"Waiting for machine key at {MACHINE_KEY_PATH} ...")
     key_data = wait_for_machine_key(MACHINE_KEY_PATH)
     print(f"  Loaded key for user {key_data['userId']}")
@@ -213,10 +151,11 @@ def main():
 
     with httpx.Client(headers=headers, timeout=30.0) as client:
 
-        # ── Project ──────────────────────────────────────────────────────────
-        print("Creating project 'stuf' ...")
+        # ── Project ───────────────────────────────────────────────────────────
+        proj_cfg = fixture["project"]
+        print(f"Creating project '{proj_cfg['name']}' ...")
         project = api(client, "post", "/management/v1/projects", json={
-            "name": "stuf",
+            "name": proj_cfg["name"],
             "projectRoleAssertion": True,
             "projectRoleCheck": False,
             "hasProjectCheck": False,
@@ -227,30 +166,20 @@ def main():
 
         # ── Project roles ─────────────────────────────────────────────────────
         print("Creating project roles ...")
-        role_defs = [
-            ("admin", "Administrator"),
-            ("trust-architect", "Trust Architect"),
-            ("project-participant", "Project Participant"),
-            ("collection-test", "Collection Test"),
-            ("service", "Service Account"),
-        ]
-        for role_key, display_name in role_defs:
+        for role in proj_cfg["roles"]:
             api(client, "post", f"/management/v1/projects/{project_id}/roles", json={
-                "roleKey": role_key,
-                "displayName": display_name,
+                "roleKey": role["key"],
+                "displayName": role["displayName"],
                 "group": "",
             })
-            print(f"  {role_key}")
+            print(f"  {role['key']}")
 
-        # ── OIDC application: stuf-spa ─────────────────────────────────────
-        print("Creating OIDC app 'stuf-spa' ...")
+        # ── OIDC application: spa ─────────────────────────────────────────────
+        spa_cfg = fixture["apps"]["spa"]
+        print(f"Creating OIDC app '{spa_cfg['name']}' ...")
         spa_app = api(client, "post", f"/management/v1/projects/{project_id}/apps/oidc", json={
-            "name": "stuf-spa",
-            "redirectUris": [
-                "http://localhost:3000",
-                "http://localhost:3100",
-                "http://spa-e2e:3000",
-            ],
+            "name": spa_cfg["name"],
+            "redirectUris": spa_cfg["redirectUris"],
             "responseTypes": ["OIDC_RESPONSE_TYPE_CODE"],
             "grantTypes": [
                 "OIDC_GRANT_TYPE_AUTHORIZATION_CODE",
@@ -258,11 +187,7 @@ def main():
             ],
             "appType": "OIDC_APP_TYPE_USER_AGENT",
             "authMethodType": "OIDC_AUTH_METHOD_TYPE_NONE",
-            "postLogoutRedirectUris": [
-                "http://localhost:3000",
-                "http://localhost:3100",
-                "http://spa-e2e:3000",
-            ],
+            "postLogoutRedirectUris": spa_cfg["postLogoutRedirectUris"],
             "version": "OIDC_VERSION_1_0",
             "accessTokenType": "OIDC_TOKEN_TYPE_JWT",
             "accessTokenRoleAssertion": True,
@@ -273,19 +198,19 @@ def main():
             "skipNativeAppSuccessPage": False,
         })
         spa_client_id = spa_app["clientId"]
-        spa_app_id = spa_app["appId"]
         print(f"  client_id={spa_client_id}")
 
-        # ── API application: stuf-api (audience target) ─────────────────────
-        print("Creating API app 'stuf-api' ...")
+        # ── API application (audience target) ─────────────────────────────────
+        api_cfg = fixture["apps"]["api"]
+        print(f"Creating API app '{api_cfg['name']}' ...")
         api_app = api(client, "post", f"/management/v1/projects/{project_id}/apps/api", json={
-            "name": "stuf-api",
+            "name": api_cfg["name"],
             "authMethodType": "API_AUTH_METHOD_TYPE_PRIVATE_KEY_JWT",
         })
         api_app_client_id = api_app["clientId"]
         print(f"  client_id={api_app_client_id}")
 
-        # ── Action: inject collections + preferred_username ──────────────────
+        # ── Action: inject collections + preferred_username ───────────────────
         print("Creating 'injectCollections' action ...")
         action = api(client, "post", "/management/v1/actions", json={
             "name": "injectCollections",
@@ -300,53 +225,46 @@ def main():
         api(client, "post", "/management/v1/flows/2/trigger/4", json={"actionIds": [action_id]})
         print("  trigger set (CUSTOMISE_TOKEN / PRE_ACCESS_TOKEN_CREATION)")
 
-        # ── Update existing admin user (created by first-instance) ───────────
-        # Search by email; FIRSTINSTANCE_ORG_HUMAN_USERNAME sets the loginName
-        # but the internal userName may include an org suffix in some versions.
-        print(f"Looking up first-instance admin user (email={ZITADEL_ADMIN_EMAIL}) ...")
-        search_resp = api(client, "post", "/management/v1/users/_search", json={
-            "query": {"limit": 5, "asc": True},
-            "queries": [{"emailQuery": {
-                "emailAddress": ZITADEL_ADMIN_EMAIL,
-                "method": "TEXT_QUERY_METHOD_EQUALS",
-            }}],
-        })
-        admin_results = search_resp.get("result", [])
-        if admin_results:
-            admin_user_id = admin_results[0]["id"]
-            print(f"  Found admin user_id={admin_user_id}")
-            api(client, "post", f"/management/v1/users/{admin_user_id}/grants", json={
-                "projectId": project_id,
-                "roleKeys": ["admin"],
-            })
-            set_user_metadata(client, admin_user_id, "collections",
-                '{"test":["read","write","delete"],"restricted":["read","write","delete"],"shared":["read","write","delete"]}')
-            print("  Granted admin role + set collections")
-        else:
-            print("  WARNING: first-instance admin user not found; skipping")
-
-        # ── Human test users ──────────────────────────────────────────────────
-        print("Creating human test users ...")
-        for user_def in HUMAN_USERS:
-            u = api(client, "post", "/management/v1/users/human", json={
-                "userName": user_def["username"],
-                "profile": {
-                    "firstName": user_def["firstName"],
-                    "lastName": user_def["lastName"],
-                    "displayName": f"{user_def['firstName']} {user_def['lastName']}",
-                    "preferredLanguage": "en",
-                },
-                "email": {
-                    "email": user_def["email"],
-                    "isEmailVerified": True,
-                },
-                "password": {
-                    "value": user_def["password"],
-                    "changeRequired": False,
-                },
-            })
-            user_id = u["userId"]
-            print(f"  {user_def['username']} → {user_id}")
+        # ── Human users ───────────────────────────────────────────────────────
+        print("Processing human users ...")
+        for user_def in fixture["human_users"]:
+            if user_def.get("existing"):
+                # Created by ZITADEL_FIRSTINSTANCE_*; look up by email, then
+                # apply roles and collections metadata only.
+                email = user_def["email"]
+                search = api(client, "post", "/management/v1/users/_search", json={
+                    "query": {"limit": 5, "asc": True},
+                    "queries": [{"emailQuery": {
+                        "emailAddress": email,
+                        "method": "TEXT_QUERY_METHOD_EQUALS",
+                    }}],
+                })
+                results = search.get("result", [])
+                if not results:
+                    print(f"  WARNING: existing user {email!r} not found; skipping")
+                    continue
+                user_id = results[0]["id"]
+                print(f"  (existing) {email} → {user_id}")
+            else:
+                u = api(client, "post", "/management/v1/users/human", json={
+                    "userName": user_def["username"],
+                    "profile": {
+                        "firstName": user_def["firstName"],
+                        "lastName": user_def["lastName"],
+                        "displayName": f"{user_def['firstName']} {user_def['lastName']}",
+                        "preferredLanguage": "en",
+                    },
+                    "email": {
+                        "email": user_def["email"],
+                        "isEmailVerified": True,
+                    },
+                    "password": {
+                        "value": user_def["password"],
+                        "changeRequired": False,
+                    },
+                })
+                user_id = u["userId"]
+                print(f"  {user_def['username']} → {user_id}")
 
             if user_def.get("roles"):
                 api(client, "post", f"/management/v1/users/{user_id}/grants", json={
@@ -355,7 +273,7 @@ def main():
                 })
 
             if user_def.get("collections"):
-                set_user_metadata(client, user_id, "collections", user_def["collections"])
+                set_collections_metadata(client, user_id, user_def["collections"])
 
             if user_def.get("disabled"):
                 # Newly-created users are in "initial" state and cannot be
@@ -363,30 +281,35 @@ def main():
                 api(client, "post", f"/management/v1/users/{user_id}/_lock", json={})
                 print(f"    (locked)")
 
-        # ── Machine user: backup-service ──────────────────────────────────────
-        print("Creating machine user 'backup-service' ...")
-        backup_user = api(client, "post", "/management/v1/users/machine", json={
-            "userName": "backup-service",
-            "name": "Backup Service",
-            "description": "Service account for backup operations",
-            "accessTokenType": "ACCESS_TOKEN_TYPE_JWT",
-        })
-        backup_user_id = backup_user["userId"]
-        print(f"  user_id={backup_user_id}")
+        # ── Machine users ─────────────────────────────────────────────────────
+        print("Creating machine users ...")
+        machine_client_id = None
+        machine_client_secret = None
+        for mu_def in fixture["machine_users"]:
+            mu = api(client, "post", "/management/v1/users/machine", json={
+                "userName": mu_def["username"],
+                "name": mu_def["name"],
+                "description": mu_def.get("description", ""),
+                "accessTokenType": "ACCESS_TOKEN_TYPE_JWT",
+            })
+            mu_id = mu["userId"]
+            print(f"  {mu_def['username']} → {mu_id}")
 
-        api(client, "post", f"/management/v1/users/{backup_user_id}/grants", json={
-            "projectId": project_id,
-            "roleKeys": ["service"],
-        })
-        set_user_metadata(client, backup_user_id, "collections", '{"test":["read"],"shared":["read"]}')
+            if mu_def.get("roles"):
+                api(client, "post", f"/management/v1/users/{mu_id}/grants", json={
+                    "projectId": project_id,
+                    "roleKeys": mu_def["roles"],
+                })
 
-        # Generate client credentials for backup-service
-        secret_resp = api(client, "put", f"/management/v1/users/{backup_user_id}/secret", json={})
-        backup_client_id = secret_resp.get("clientId", backup_user_id)
-        backup_client_secret = secret_resp.get("clientSecret", "")
-        print(f"  client_id={backup_client_id}")
+            if mu_def.get("collections"):
+                set_collections_metadata(client, mu_id, mu_def["collections"])
 
-        # ── Machine user: login-client (IAM_LOGIN_CLIENT) ─────────────────────
+            secret_resp = api(client, "put", f"/management/v1/users/{mu_id}/secret", json={})
+            machine_client_id = secret_resp.get("clientId", mu_def["username"])
+            machine_client_secret = secret_resp.get("clientSecret", "")
+            print(f"    client_id={machine_client_id}")
+
+        # ── Login-client machine user (infrastructure, not in fixture) ────────
         print("Creating machine user 'login-client' for zitadel-login ...")
         login_user = api(client, "post", "/management/v1/users/machine", json={
             "userName": "login-client",
@@ -397,14 +320,12 @@ def main():
         login_user_id = login_user["userId"]
         print(f"  user_id={login_user_id}")
 
-        # Grant IAM_LOGIN_CLIENT role (admin API)
         api(client, "post", "/admin/v1/members", json={
             "userId": login_user_id,
             "roles": ["IAM_LOGIN_CLIENT"],
         })
         print("  Granted IAM_LOGIN_CLIENT")
 
-        # Generate PAT (expiry far in future for dev)
         pat_resp = api(client, "post", f"/management/v1/users/{login_user_id}/pats", json={
             "expirationDate": "2099-01-01T00:00:00Z",
         })
@@ -423,8 +344,8 @@ def main():
             "ZITADEL_STUF_PROJECT_ID": project_id,
             "ZITADEL_SPA_CLIENT_ID": spa_client_id,
             "ZITADEL_API_APP_CLIENT_ID": api_app_client_id,
-            "ZITADEL_BACKUP_SERVICE_CLIENT_ID": backup_client_id,
-            "ZITADEL_BACKUP_SERVICE_CLIENT_SECRET": backup_client_secret,
+            "ZITADEL_BACKUP_SERVICE_CLIENT_ID": machine_client_id or "",
+            "ZITADEL_BACKUP_SERVICE_CLIENT_SECRET": machine_client_secret or "",
         }
         env_file = os.path.join(BOOTSTRAP_DIR, "generated.env")
         with open(env_file, "w") as f:
@@ -436,7 +357,7 @@ def main():
         print(f"  project_id:           {project_id}")
         print(f"  spa_client_id:        {spa_client_id}")
         print(f"  api_app_client_id:    {api_app_client_id}")
-        print(f"  backup client_id:     {backup_client_id}")
+        print(f"  backup client_id:     {machine_client_id}")
         print(f"  login-token written:  {token_file}")
         print(f"  generated.env:        {env_file}")
         print("=============================")

--- a/docker/zitadel-init/provision.py
+++ b/docker/zitadel-init/provision.py
@@ -1,0 +1,450 @@
+#!/usr/bin/env python3
+"""
+Zitadel provisioning script for STUF development environment.
+Mirrors the content of docker/keycloak/data/import/realm-export.json.
+
+Run order: after Zitadel is healthy, before api/spa/zitadel-login start.
+Writes /bootstrap/login-token (PAT for zitadel-login) and
+/bootstrap/generated.env (generated client IDs for step 5 wiring).
+"""
+
+import base64
+import json
+import os
+import sys
+import time
+import uuid
+from datetime import datetime, timezone, timedelta
+
+import httpx
+import jwt
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.backends import default_backend
+
+ZITADEL_DOMAIN = os.environ.get("ZITADEL_DOMAIN", "http://localhost:8080")
+MACHINE_KEY_PATH = os.environ.get("MACHINE_KEY_PATH", "/bootstrap/zitadel-admin-sa.json")
+BOOTSTRAP_DIR = os.environ.get("BOOTSTRAP_DIR", "/bootstrap")
+ZITADEL_ADMIN_EMAIL = os.environ.get("ZITADEL_ADMIN_EMAIL", "admin@example.com")
+
+# Injected into every access token via the preAccessTokenCreation trigger.
+# - preferred_username: not in Zitadel JWT access tokens by default; mirrors
+#   the Keycloak claim the STUF API middleware reads.
+# - collections: user metadata injected as a JSON object claim; mirrors the
+#   Keycloak stuf:access scope's collections attribute mapper.
+# Metadata values arrive as base64-encoded strings in ctx.v1.user.metadataList.
+COLLECTIONS_ACTION_SCRIPT = """\
+function preAccessTokenCreation(ctx, api) {
+  api.v1.claims.setClaim("preferred_username", ctx.v1.user.preferredLoginName);
+  var md = ctx.v1.user.metadataList;
+  if (!md) { return; }
+  for (var i = 0; i < md.length; i++) {
+    if (md[i].key === "collections") {
+      try {
+        api.v1.claims.setClaim("collections", JSON.parse(atob(md[i].value)));
+      } catch (e) {}
+      break;
+    }
+  }
+}
+"""
+
+HUMAN_USERS = [
+    {
+        "username": "testuser",
+        "firstName": "Test",
+        "lastName": "User",
+        "email": "testuser@example.com",
+        "password": "password",
+        "roles": ["project-participant"],
+        "collections": '{"test":["read","write","delete"],"collection-1-docs":["read","write"],"collection-2-contracts":["read"],"collection-3-cat-pics":["read","write","delete"]}',
+    },
+    {
+        "username": "test-admin",
+        "firstName": "Test",
+        "lastName": "Admin",
+        "email": "admin@test.example.com",
+        "password": "test-password",
+        "roles": ["admin"],
+        "collections": '{"test":["read","write","delete"],"restricted":["read","write","delete"],"shared":["read","write","delete"]}',
+    },
+    {
+        "username": "test-trust-architect",
+        "firstName": "Test",
+        "lastName": "Architect",
+        "email": "ta@test.example.com",
+        "password": "test-password",
+        "roles": ["trust-architect"],
+        "collections": '{"test":["read","write","delete"],"restricted":["read","write","delete"],"shared":["read","write","delete"]}',
+    },
+    {
+        "username": "test-user-full",
+        "firstName": "Test",
+        "lastName": "FullUser",
+        "email": "full@test.example.com",
+        "password": "test-password",
+        "roles": ["project-participant"],
+        "collections": '{"test":["read","write"],"restricted":["read","write"],"shared":["read","write"]}',
+    },
+    {
+        "username": "test-user-limited",
+        "firstName": "Test",
+        "lastName": "LimitedUser",
+        "email": "limited@test.example.com",
+        "password": "test-password",
+        "roles": ["project-participant"],
+        "collections": '{"test":["read","write"]}',
+    },
+    {
+        "username": "test-user-shared",
+        "firstName": "Test",
+        "lastName": "SharedUser",
+        "email": "shared@test.example.com",
+        "password": "test-password",
+        "roles": ["project-participant"],
+        "collections": '{"shared":["read","write"]}',
+    },
+    {
+        "username": "test-user-inactive",
+        "firstName": "Test",
+        "lastName": "InactiveUser",
+        "email": "inactive@test.example.com",
+        "password": "test-password",
+        "roles": ["project-participant"],
+        "collections": '{"test":["read","write"]}',
+        "disabled": True,
+    },
+]
+
+
+def wait_for_machine_key(path, timeout=120):
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        if os.path.exists(path):
+            try:
+                with open(path) as f:
+                    data = json.load(f)
+                if data.get("key") and data.get("userId"):
+                    return data
+            except (json.JSONDecodeError, KeyError):
+                pass
+        time.sleep(2)
+    raise RuntimeError(f"Machine key not found at {path} after {timeout}s")
+
+
+def get_issuer_url():
+    for attempt in range(30):
+        try:
+            resp = httpx.get(f"{ZITADEL_DOMAIN}/.well-known/openid-configuration", timeout=5)
+            resp.raise_for_status()
+            return resp.json()["issuer"]
+        except Exception:
+            time.sleep(2)
+    raise RuntimeError("Could not reach Zitadel OIDC discovery endpoint")
+
+
+def create_jwt_assertion(key_data, issuer_url):
+    user_id = key_data["userId"]
+    key_id = key_data["keyId"]
+    private_key_pem = key_data["key"]
+
+    private_key = serialization.load_pem_private_key(
+        private_key_pem.encode(),
+        password=None,
+        backend=default_backend(),
+    )
+
+    now = datetime.now(timezone.utc)
+    payload = {
+        "iss": user_id,
+        "sub": user_id,
+        "aud": [issuer_url],
+        "iat": int(now.timestamp()),
+        "exp": int((now + timedelta(minutes=5)).timestamp()),
+        "jti": str(uuid.uuid4()),
+    }
+
+    return jwt.encode(payload, private_key, algorithm="RS256", headers={"kid": key_id})
+
+
+def get_access_token(key_data, issuer_url):
+    assertion = create_jwt_assertion(key_data, issuer_url)
+    resp = httpx.post(
+        f"{ZITADEL_DOMAIN}/oauth/v2/token",
+        data={
+            "grant_type": "urn:ietf:params:oauth:grant-type:jwt-bearer",
+            "assertion": assertion,
+            "scope": "openid urn:zitadel:iam:org:project:id:zitadel:aud",
+        },
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+    )
+    resp.raise_for_status()
+    return resp.json()["access_token"]
+
+
+def api(client, method, path, **kwargs):
+    url = f"{ZITADEL_DOMAIN}{path}"
+    resp = getattr(client, method)(url, **kwargs)
+    if not resp.is_success:
+        print(f"  ERROR: {method.upper()} {path} → {resp.status_code}")
+        print(f"  {resp.text[:500]}")
+        resp.raise_for_status()
+    return resp.json() if resp.content else {}
+
+
+def set_user_metadata(client, user_id, key, value_str):
+    encoded = base64.b64encode(value_str.encode()).decode()
+    api(client, "post", f"/management/v1/users/{user_id}/metadata/{key}", json={"value": encoded})
+
+
+def main():
+    print(f"Waiting for machine key at {MACHINE_KEY_PATH} ...")
+    key_data = wait_for_machine_key(MACHINE_KEY_PATH)
+    print(f"  Loaded key for user {key_data['userId']}")
+
+    print("Fetching OIDC issuer URL ...")
+    issuer_url = get_issuer_url()
+    print(f"  Issuer: {issuer_url}")
+
+    print("Obtaining access token ...")
+    token = get_access_token(key_data, issuer_url)
+    print("  OK")
+
+    headers = {"Authorization": f"Bearer {token}", "Content-Type": "application/json"}
+
+    with httpx.Client(headers=headers, timeout=30.0) as client:
+
+        # ── Project ──────────────────────────────────────────────────────────
+        print("Creating project 'stuf' ...")
+        project = api(client, "post", "/management/v1/projects", json={
+            "name": "stuf",
+            "projectRoleAssertion": True,
+            "projectRoleCheck": False,
+            "hasProjectCheck": False,
+            "privateLabelingSetting": "PRIVATE_LABELING_SETTING_UNSPECIFIED",
+        })
+        project_id = project["id"]
+        print(f"  project_id={project_id}")
+
+        # ── Project roles ─────────────────────────────────────────────────────
+        print("Creating project roles ...")
+        role_defs = [
+            ("admin", "Administrator"),
+            ("trust-architect", "Trust Architect"),
+            ("project-participant", "Project Participant"),
+            ("collection-test", "Collection Test"),
+            ("service", "Service Account"),
+        ]
+        for role_key, display_name in role_defs:
+            api(client, "post", f"/management/v1/projects/{project_id}/roles", json={
+                "roleKey": role_key,
+                "displayName": display_name,
+                "group": "",
+            })
+            print(f"  {role_key}")
+
+        # ── OIDC application: stuf-spa ─────────────────────────────────────
+        print("Creating OIDC app 'stuf-spa' ...")
+        spa_app = api(client, "post", f"/management/v1/projects/{project_id}/apps/oidc", json={
+            "name": "stuf-spa",
+            "redirectUris": [
+                "http://localhost:3000",
+                "http://localhost:3100",
+                "http://spa-e2e:3000",
+            ],
+            "responseTypes": ["OIDC_RESPONSE_TYPE_CODE"],
+            "grantTypes": [
+                "OIDC_GRANT_TYPE_AUTHORIZATION_CODE",
+                "OIDC_GRANT_TYPE_REFRESH_TOKEN",
+            ],
+            "appType": "OIDC_APP_TYPE_USER_AGENT",
+            "authMethodType": "OIDC_AUTH_METHOD_TYPE_NONE",
+            "postLogoutRedirectUris": [
+                "http://localhost:3000",
+                "http://localhost:3100",
+                "http://spa-e2e:3000",
+            ],
+            "version": "OIDC_VERSION_1_0",
+            "accessTokenType": "OIDC_TOKEN_TYPE_JWT",
+            "accessTokenRoleAssertion": True,
+            "idTokenRoleAssertion": True,
+            "idTokenUserinfoAssertion": True,
+            "clockSkew": "0s",
+            "additionalOrigins": [],
+            "skipNativeAppSuccessPage": False,
+        })
+        spa_client_id = spa_app["clientId"]
+        spa_app_id = spa_app["appId"]
+        print(f"  client_id={spa_client_id}")
+
+        # ── API application: stuf-api (audience target) ─────────────────────
+        print("Creating API app 'stuf-api' ...")
+        api_app = api(client, "post", f"/management/v1/projects/{project_id}/apps/api", json={
+            "name": "stuf-api",
+            "authMethodType": "API_AUTH_METHOD_TYPE_PRIVATE_KEY_JWT",
+        })
+        api_app_client_id = api_app["clientId"]
+        print(f"  client_id={api_app_client_id}")
+
+        # ── Action: inject collections + preferred_username ──────────────────
+        print("Creating 'injectCollections' action ...")
+        action = api(client, "post", "/management/v1/actions", json={
+            "name": "injectCollections",
+            "script": COLLECTIONS_ACTION_SCRIPT,
+            "timeout": "10s",
+            "allowedToFail": True,
+        })
+        action_id = action["id"]
+        print(f"  action_id={action_id}")
+
+        # Flow type 2 = CUSTOMISE_TOKEN, trigger type 4 = PRE_ACCESS_TOKEN_CREATION
+        api(client, "post", "/management/v1/flows/2/trigger/4", json={"actionIds": [action_id]})
+        print("  trigger set (CUSTOMISE_TOKEN / PRE_ACCESS_TOKEN_CREATION)")
+
+        # ── Update existing admin user (created by first-instance) ───────────
+        # Search by email; FIRSTINSTANCE_ORG_HUMAN_USERNAME sets the loginName
+        # but the internal userName may include an org suffix in some versions.
+        print(f"Looking up first-instance admin user (email={ZITADEL_ADMIN_EMAIL}) ...")
+        search_resp = api(client, "post", "/management/v1/users/_search", json={
+            "query": {"limit": 5, "asc": True},
+            "queries": [{"emailQuery": {
+                "emailAddress": ZITADEL_ADMIN_EMAIL,
+                "method": "TEXT_QUERY_METHOD_EQUALS",
+            }}],
+        })
+        admin_results = search_resp.get("result", [])
+        if admin_results:
+            admin_user_id = admin_results[0]["id"]
+            print(f"  Found admin user_id={admin_user_id}")
+            api(client, "post", f"/management/v1/users/{admin_user_id}/grants", json={
+                "projectId": project_id,
+                "roleKeys": ["admin"],
+            })
+            set_user_metadata(client, admin_user_id, "collections",
+                '{"test":["read","write","delete"],"restricted":["read","write","delete"],"shared":["read","write","delete"]}')
+            print("  Granted admin role + set collections")
+        else:
+            print("  WARNING: first-instance admin user not found; skipping")
+
+        # ── Human test users ──────────────────────────────────────────────────
+        print("Creating human test users ...")
+        for user_def in HUMAN_USERS:
+            u = api(client, "post", "/management/v1/users/human", json={
+                "userName": user_def["username"],
+                "profile": {
+                    "firstName": user_def["firstName"],
+                    "lastName": user_def["lastName"],
+                    "displayName": f"{user_def['firstName']} {user_def['lastName']}",
+                    "preferredLanguage": "en",
+                },
+                "email": {
+                    "email": user_def["email"],
+                    "isEmailVerified": True,
+                },
+                "password": {
+                    "value": user_def["password"],
+                    "changeRequired": False,
+                },
+            })
+            user_id = u["userId"]
+            print(f"  {user_def['username']} → {user_id}")
+
+            if user_def.get("roles"):
+                api(client, "post", f"/management/v1/users/{user_id}/grants", json={
+                    "projectId": project_id,
+                    "roleKeys": user_def["roles"],
+                })
+
+            if user_def.get("collections"):
+                set_user_metadata(client, user_id, "collections", user_def["collections"])
+
+            if user_def.get("disabled"):
+                # Newly-created users are in "initial" state and cannot be
+                # deactivated; locking works across all states.
+                api(client, "post", f"/management/v1/users/{user_id}/_lock", json={})
+                print(f"    (locked)")
+
+        # ── Machine user: backup-service ──────────────────────────────────────
+        print("Creating machine user 'backup-service' ...")
+        backup_user = api(client, "post", "/management/v1/users/machine", json={
+            "userName": "backup-service",
+            "name": "Backup Service",
+            "description": "Service account for backup operations",
+            "accessTokenType": "ACCESS_TOKEN_TYPE_JWT",
+        })
+        backup_user_id = backup_user["userId"]
+        print(f"  user_id={backup_user_id}")
+
+        api(client, "post", f"/management/v1/users/{backup_user_id}/grants", json={
+            "projectId": project_id,
+            "roleKeys": ["service"],
+        })
+        set_user_metadata(client, backup_user_id, "collections", '{"test":["read"],"shared":["read"]}')
+
+        # Generate client credentials for backup-service
+        secret_resp = api(client, "put", f"/management/v1/users/{backup_user_id}/secret", json={})
+        backup_client_id = secret_resp.get("clientId", backup_user_id)
+        backup_client_secret = secret_resp.get("clientSecret", "")
+        print(f"  client_id={backup_client_id}")
+
+        # ── Machine user: login-client (IAM_LOGIN_CLIENT) ─────────────────────
+        print("Creating machine user 'login-client' for zitadel-login ...")
+        login_user = api(client, "post", "/management/v1/users/machine", json={
+            "userName": "login-client",
+            "name": "Login Client",
+            "description": "Service user for the Zitadel login UI",
+            "accessTokenType": "ACCESS_TOKEN_TYPE_JWT",
+        })
+        login_user_id = login_user["userId"]
+        print(f"  user_id={login_user_id}")
+
+        # Grant IAM_LOGIN_CLIENT role (admin API)
+        api(client, "post", "/admin/v1/members", json={
+            "userId": login_user_id,
+            "roles": ["IAM_LOGIN_CLIENT"],
+        })
+        print("  Granted IAM_LOGIN_CLIENT")
+
+        # Generate PAT (expiry far in future for dev)
+        pat_resp = api(client, "post", f"/management/v1/users/{login_user_id}/pats", json={
+            "expirationDate": "2099-01-01T00:00:00Z",
+        })
+        login_token = pat_resp["token"]
+        print("  PAT generated")
+
+        # ── Write bootstrap files ─────────────────────────────────────────────
+        os.makedirs(BOOTSTRAP_DIR, exist_ok=True)
+
+        token_file = os.path.join(BOOTSTRAP_DIR, "login-token")
+        with open(token_file, "w") as f:
+            f.write(login_token)
+        os.chmod(token_file, 0o644)
+
+        generated = {
+            "ZITADEL_STUF_PROJECT_ID": project_id,
+            "ZITADEL_SPA_CLIENT_ID": spa_client_id,
+            "ZITADEL_API_APP_CLIENT_ID": api_app_client_id,
+            "ZITADEL_BACKUP_SERVICE_CLIENT_ID": backup_client_id,
+            "ZITADEL_BACKUP_SERVICE_CLIENT_SECRET": backup_client_secret,
+        }
+        env_file = os.path.join(BOOTSTRAP_DIR, "generated.env")
+        with open(env_file, "w") as f:
+            for k, v in generated.items():
+                f.write(f"{k}={v}\n")
+        os.chmod(env_file, 0o644)
+
+        print("\n=== Provisioning complete ===")
+        print(f"  project_id:           {project_id}")
+        print(f"  spa_client_id:        {spa_client_id}")
+        print(f"  api_app_client_id:    {api_app_client_id}")
+        print(f"  backup client_id:     {backup_client_id}")
+        print(f"  login-token written:  {token_file}")
+        print(f"  generated.env:        {env_file}")
+        print("=============================")
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except Exception as e:
+        print(f"\nFATAL: {e}", file=sys.stderr)
+        sys.exit(1)

--- a/docker/zitadel-init/requirements.txt
+++ b/docker/zitadel-init/requirements.txt
@@ -1,0 +1,3 @@
+httpx==0.27.2
+PyJWT==2.9.0
+cryptography==43.0.3

--- a/docker/zitadel-init/requirements.txt
+++ b/docker/zitadel-init/requirements.txt
@@ -1,3 +1,4 @@
 httpx==0.27.2
 PyJWT==2.9.0
 cryptography==43.0.3
+PyYAML==6.0.2

--- a/tasks/0001-support-zitadel-as-oidc-provider.md
+++ b/tasks/0001-support-zitadel-as-oidc-provider.md
@@ -416,11 +416,17 @@ These need decisions or upstream investigation before implementation:
    but it's the change that decouples STUF from any one provider for
    good. Worth doing as the foundation step rather than retrofitting
    Zitadel-specific URL templates beside the Keycloak ones.
+   **Resolved (step 1).** `api/auth/middleware.py` now fetches the JWKS
+   URI from `OIDC_BASE_URL/.well-known/openid-configuration` and has no
+   provider-specific URL construction.
 
 7. **Storage choice for Zitadel.** Zitadel requires Postgres. STUF's
    compose has no Postgres today. A dedicated `zitadel-postgres` service
    keeps this self-contained; it can be on the `zitadel` profile so the
    default Keycloak path stays unaffected.
+   **Resolved (step 3).** `zitadel-postgres` (Postgres 17) added to
+   `docker-compose.yml` under the `zitadel` profile. Default Keycloak
+   path is unaffected.
 
 8. **Compose-profile strategy.** The cleanest way to ship parallel
    provider support is `docker compose --profile keycloak up` (today's
@@ -430,6 +436,17 @@ These need decisions or upstream investigation before implementation:
    service names — `keycloak-e2e` is hard-coded in several Playwright
    fixtures and would have to become provider-parameterised or
    provider-renamed.
+   **Partially resolved (step 3).** Profile strategy implemented:
+   `--profile keycloak` starts Keycloak on :8080; `--profile zitadel`
+   starts the Zitadel stack on :8080/:8090; bare `docker compose up`
+   starts minio/api/spa only. The e2e service-name issue (hardcoded
+   `keycloak-e2e` in Playwright fixtures) remains open for step 6.
+   Additional discovery: `zitadel-login` (v4.14.0) is the correct image
+   name (not `zitadel/login`); `ZITADEL_DEFAULTINSTANCE_FEATURES_LOGINV2_BASEURI`
+   must be set to `http://localhost:8090/ui/v2/login` so Zitadel
+   constructs the correct redirect URL; the login container requires
+   `ZITADEL_SERVICE_USER_TOKEN` (IAM_LOGIN_CLIENT role) to serve the
+   login page — provisioned in step 4.
 
 ## Suggested implementation order
 

--- a/tasks/0001-support-zitadel-as-oidc-provider.md
+++ b/tasks/0001-support-zitadel-as-oidc-provider.md
@@ -374,6 +374,14 @@ These need decisions or upstream investigation before implementation:
    project roles would invert the data model (one role per
    `{collection}:{permission}` combination) and is likely overkill for a
    mostly-attribute-based model.
+   **Resolved (step 4).** Keeping the custom claim. The `injectCollections`
+   Action (in `docker/zitadel-init/provision.py`) is deployed to the
+   `CUSTOMISE_TOKEN / PRE_ACCESS_TOKEN_CREATION` trigger. It reads the
+   `collections` key from user metadata (base64-decoded JSON) and injects
+   it as a top-level claim. It also injects `preferred_username` from
+   `ctx.v1.user.preferredLoginName` to fill the gap Zitadel has vs Keycloak.
+   Note: the Action fires for authorisation-code flows; behaviour on
+   `client_credentials` flows needs verification in step 5.
 
 2. **JWT vs opaque tokens.** Default Zitadel access tokens are opaque. Two
    options:
@@ -384,6 +392,10 @@ These need decisions or upstream investigation before implementation:
      round-trip per request.
    Recommend (a). It is also closer to the current Keycloak behaviour, so
    the same middleware path works for both providers.
+   **Resolved (step 4).** `stuf-spa` is created with `accessTokenType:
+   OIDC_TOKEN_TYPE_JWT` and `idTokenUserinfoAssertion: true`. The API app
+   uses `API_AUTH_METHOD_TYPE_PRIVATE_KEY_JWT`. The `backup-service` machine
+   user is created with `ACCESS_TOKEN_TYPE_JWT`.
 
 3. **Auto-generated client IDs.** Zitadel does not let you choose the
    client ID for an OIDC application — it's a generated identifier. That
@@ -392,6 +404,15 @@ These need decisions or upstream investigation before implementation:
    updated compose env vars), rather than the stable string literals
    (`stuf-api`, `stuf-spa`, `backup-service`) we use today. This is the
    single biggest ergonomic regression from the operator's perspective.
+   **Partially resolved (step 4).** `zitadel-init` writes the generated IDs
+   to `/bootstrap/generated.env` (named volume `zitadel-bootstrap`). For
+   step 5, compose needs to read these values into `api` and `spa` env vars.
+   One option: after `zitadel-init` completes, a second one-shot container
+   copies `generated.env` to a host-bound path so compose can pick it up
+   via `env_file`. Another option: wire env vars via `docker compose run`.
+   Exception: `backup-service` machine user's `clientId` IS the userName
+   (`backup-service`), so it is stable across restarts — only the secret
+   rotates.
 
 4. **Service account credentials.** `backup-service` today has a
    well-known `clientId=backup-service` and `secret=backup-service-secret`
@@ -400,6 +421,10 @@ These need decisions or upstream investigation before implementation:
    client-secret (auto-generated) or a private-key JWT. The init script
    has to write the resulting credentials to a place the e2e fixture can
    read — likely an `.env` file mounted into the test container.
+   **Partially resolved (step 4).** `backup-service` machine user created;
+   client credentials (`clientId=backup-service`, auto-generated secret)
+   written to `/bootstrap/generated.env`. `client_credentials` token flow
+   verified working. E2E fixture wiring deferred to step 5.
 
 5. **Token-type discrimination semantics.** `get_current_principal`'s
    distinction between user tokens and service-account tokens is the most
@@ -436,17 +461,21 @@ These need decisions or upstream investigation before implementation:
    service names — `keycloak-e2e` is hard-coded in several Playwright
    fixtures and would have to become provider-parameterised or
    provider-renamed.
-   **Partially resolved (step 3).** Profile strategy implemented:
+   **Partially resolved (step 3 + step 4).** Profile strategy implemented:
    `--profile keycloak` starts Keycloak on :8080; `--profile zitadel`
    starts the Zitadel stack on :8080/:8090; bare `docker compose up`
    starts minio/api/spa only. The e2e service-name issue (hardcoded
    `keycloak-e2e` in Playwright fixtures) remains open for step 6.
-   Additional discovery: `zitadel-login` (v4.14.0) is the correct image
-   name (not `zitadel/login`); `ZITADEL_DEFAULTINSTANCE_FEATURES_LOGINV2_BASEURI`
-   must be set to `http://localhost:8090/ui/v2/login` so Zitadel
-   constructs the correct redirect URL; the login container requires
-   `ZITADEL_SERVICE_USER_TOKEN` (IAM_LOGIN_CLIENT role) to serve the
-   login page — provisioned in step 4.
+   Additional discovery (step 4): Zitadel validates the HTTP `Host` header
+   on every incoming request against `ZITADEL_EXTERNALDOMAIN` (localhost).
+   Any Docker-internal request using the service hostname (`zitadel:8080`)
+   returns "Instance not found". Fix: `zitadel-init` and `zitadel-login`
+   both use `network_mode: host` so they call `http://localhost:8080`
+   directly (the published port) — the `Host` header matches. For step 5,
+   `api` will also need either host networking or a proxy, or the env var
+   `OIDC_BASE_URL` must use `localhost` rather than `zitadel`.
+   `zitadel-login` uses `PORT` env var to bind on 8090 instead of the
+   default 3000.
 
 ## Suggested implementation order
 


### PR DESCRIPTION
Ref: #85 . Follows #87 

## Summary

- **Step 3**: adds `zitadel-postgres`, `zitadel`, and `zitadel-login` services under a `--profile zitadel` flag; Keycloak gains the symmetric `--profile keycloak` flag so both stacks share port 8080 without conflict
- **Step 4**: adds `docker/zitadel-init/` — a Python provisioning container that runs once after Zitadel is healthy and creates the full STUF identity model (project, roles, OIDC apps, users, collections Action, backup-service machine user, and the login-client PAT for zitadel-login)
- User/role/app data lives in `docker/zitadel-init/dev/instance.yaml` (mirroring `docker/keycloak/data/import/realm-export.json`); `provision.py` is pure logic

## Key findings

- Zitadel v4 validates the HTTP `Host` header against `ZITADEL_EXTERNALDOMAIN` on every request; internal Docker service calls (`zitadel:8080`) return "Instance not found". `zitadel-init` and `zitadel-login` both use `network_mode: host` so they call `http://localhost:8080` directly.
- `zitadel-login` requires a `ZITADEL_SERVICE_USER_TOKEN` PAT (IAM_LOGIN_CLIENT role) before it will serve any login page. The init container provisions this and writes it to the `zitadel-bootstrap` named volume; `zitadel-login` reads it at startup via the overridden entrypoint.
- Newly-created Zitadel users are in `initial` state and cannot be deactivated; `_lock` is used instead for `test-user-inactive`.
- `busybox` chmod 777 on the bootstrap volume is intentional: three containers with different users (`zitadel`, root, `nextjs`) share it, and cross-image UID lookup is not feasible for dev (will need more effort for a deployment env).

## Verified

```
docker compose --profile zitadel up -d
# zitadel-postgres, zitadel, zitadel-bootstrap-init, zitadel-init all complete successfully
# zitadel-login reaches healthy with no "Instance not found" errors
curl http://localhost:8080/.well-known/openid-configuration   # issuer: http://localhost:8080
curl http://localhost:8090/ui/v2/login/healthy                # {}
# backup-service client_credentials token flow verified
```

## Test plan

- [ ] `docker compose --profile zitadel up -d` — all containers reach healthy/exited-0
- [ ] Admin console reachable at `http://localhost:8080/ui/console` (login: `admin` / `Password1!`)
- [ ] OIDC discovery returns `issuer: http://localhost:8080`
- [ ] Login UI healthy at `http://localhost:8090/ui/v2/login/healthy`
- [ ] Navigating to `http://localhost:8080/ui/console` redirects through `http://localhost:8090/ui/v2/login/login?authRequest=...` with a login form
- [ ] `docker compose --profile keycloak up -d` still works (Keycloak on :8080 unchanged)