### PR TITLE
zitadel: provider-agnostic middleware, e2e fixtures, and browser tests (steps 5-7)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -111,7 +111,7 @@ clean:
 	@rm -f api/.coverage
 	@rm -rf $(VENV_DIR)
 	@tests/run.sh clean
-	@echo "Cleaning Keycloak database..."
+	@echo "Cleaning Keycloak local state..."
 	@rm -rf docker/keycloak/data/h2
 	@rm -rf docker/keycloak/data/transaction-logs
 	@echo "Cleaning SPA generated config..."
@@ -153,7 +153,7 @@ test-cov: $(VENV_DIR)/dev-requirements.stamp
 # Start SPA in development mode with hot reloading
 spa-dev:
 	@echo "Starting SPA in development mode with hot reloading..."
-	@echo "This includes full environment (API, Keycloak, MinIO) + fast SPA reloading"
+	@echo "This includes full environment (API, IDP, MinIO) + fast SPA reloading"
 	@echo "Access at: http://localhost:3000"
 	@docker compose -f docker-compose.yml -f docker-compose.dev.yml up --build
 
@@ -172,7 +172,7 @@ spa-build:
 spa-stop:
 	@echo "Stopping SPA services..."
 	@docker compose down
-	@echo "Cleaning Keycloak database..."
+	@echo "Cleaning Keycloak local state..."
 	@rm -rf docker/keycloak/data/h2
 	@rm -rf docker/keycloak/data/transaction-logs
 	@echo "Cleaning generated config..."

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ STUF can be run locally using Docker Compose for development and testing purpose
    cp .env.example .env
    ```
 
-   Note: The `.env` file contains configuration for Keycloak realms, roles, and client IDs.
+   Note: The `.env` file contains configuration for the OIDC provider, roles, and client IDs.
    Edit this file to customize your local development environment.
 
 4. Start the Docker Compose environment:
@@ -137,26 +137,31 @@ STUF can be run locally using Docker Compose for development and testing purpose
 
 5. Access the components:
    - SPA (Frontend): http://localhost:3000
-     - Login with admin/password or other test users from realm-export.json
+     - Login with users from the active IDP (see below)
    - API: http://localhost:8000
      - Health check: http://localhost:8000/api/health
      - API info: http://localhost:8000/api/info
-   - Keycloak Admin Console: http://localhost:8080/admin (admin/admin)
+   - **Keycloak** (default profile): Admin console at http://localhost:8080/admin (admin/admin)
+   - **Zitadel** (zitadel profile): Admin console at http://localhost:8080/ui/console (admin / Password1!)
    - MinIO:
      - API endpoint: http://localhost:9000
      - Web console: http://localhost:9001 (minioadmin/minioadmin)
 
+Use `docker compose --profile keycloak up -d` for Keycloak (default) or
+`docker compose --profile zitadel up -d` for Zitadel.
+
 ### Environment Components
 
-- **Keycloak**: Authentication and authorization server
+- **Keycloak** (default profile): OIDC identity provider
   - Development-only admin credentials: admin/admin
-  - Configured with realm: stuf
-  - Clients:
-    - stuf-spa: Public client for the SPA
-    - stuf-api: Confidential client with service account
-  - Roles:
-    - admin: Administrator role with full access
-    - collection: Collection-specific access roles
+  - Configured from `docker/keycloak/data/import/realm-export.json`
+  - Clients: stuf-spa (public), stuf-api (confidential/service accounts)
+  - Roles: admin, trust-architect, project-participant, collection-test, service
+
+- **Zitadel** (zitadel profile): alternative OIDC identity provider
+  - Admin credentials: admin / Password1!
+  - Provisioned by `docker/zitadel-init/` from `docker/zitadel-init/dev/instance.yaml`
+  - Login UI served at http://localhost:8090
   - Test users:
     - admin@example.com / password (admin role)
 - **MinIO**: S3-compatible object storage

--- a/api/auth/middleware.py
+++ b/api/auth/middleware.py
@@ -30,11 +30,34 @@ OIDC_VALID_AUDIENCES = set(
     if a.strip()
 )
 
+# Client ID of the SPA OIDC application. Used to distinguish user tokens (where
+# azp matches the SPA client) from service-account tokens. For Keycloak the SPA
+# client ID is the stable string "stuf-spa"; for Zitadel it is an auto-generated
+# UUID written to /bootstrap/generated.env by zitadel-init.
+OIDC_SPA_CLIENT_ID = os.environ.get("OIDC_SPA_CLIENT_ID", "stuf-spa")
+
 bearer_scheme = HTTPBearer(auto_error=False)
 
 _discovery_doc: dict = {}
 _jwks_cache: dict = {"keys": [], "fetched_at": 0.0}
 _JWKS_TTL = 300  # seconds
+
+
+def _extract_roles(token_payload: dict) -> list:
+    """Extract role list from a token, handling both Keycloak and Zitadel shapes.
+
+    Keycloak puts roles at realm_access.roles (flat list).
+    Zitadel puts project roles at urn:zitadel:iam:org:project:roles
+    (dict of {role_key: {org_id: org_domain}}).
+    """
+    realm_access = token_payload.get("realm_access", {})
+    roles = realm_access.get("roles", [])
+    if roles:
+        return roles
+    zitadel_roles = token_payload.get("urn:zitadel:iam:org:project:roles", {})
+    if isinstance(zitadel_roles, dict):
+        return list(zitadel_roles.keys())
+    return []
 
 
 def _fetch_discovery() -> dict:
@@ -174,9 +197,7 @@ async def get_current_user(
         )
         raise credentials_exception
 
-    # Extract roles from realm_access
-    realm_access = token_payload.get("realm_access", {})
-    roles = realm_access.get("roles", [])
+    roles = _extract_roles(token_payload)
 
     # Extract and parse collections from custom claim
     collections = {}
@@ -254,9 +275,7 @@ async def get_current_service_account(
             headers={"WWW-Authenticate": "Bearer"},
         )
 
-    # Extract roles from realm_access
-    realm_access = token_payload.get("realm_access", {})
-    roles = realm_access.get("roles", [])
+    roles = _extract_roles(token_payload)
 
     # Extract and parse collections from custom claim
     collections = {}
@@ -336,7 +355,7 @@ async def get_current_principal(
 
     # Service accounts typically don't have openid/profile scopes and have specific azp
     has_service_indicators = (
-        azp != "stuf-spa"  # Users typically use SPA client
+        azp != OIDC_SPA_CLIENT_ID  # Users use the SPA OIDC client
         and "openid" not in scope  # Service accounts usually don't have openid scope
         and "profile" not in scope  # Service accounts usually don't have profile scope
         and "email" not in scope  # Service accounts usually don't have email scope

--- a/api/domain/models.py
+++ b/api/domain/models.py
@@ -64,7 +64,7 @@ class User(BaseModel):
 class ServiceAccount(BaseModel):
     """Domain model representing a service account with API access permissions"""
 
-    client_id: str = Field(..., description="Unique client identifier from Keycloak")
+    client_id: str = Field(..., description="Unique client identifier (azp claim)")
     name: str = Field(..., description="Human-readable service account name")
     description: str = Field(
         default="", description="Description of service account purpose"

--- a/api/tests/e2e/conftest.py
+++ b/api/tests/e2e/conftest.py
@@ -25,39 +25,69 @@ except ImportError:
     # Fallback if import fails
     ensure_services_ready = None
 
-# E2E configuration - uses browser E2E Docker services
-# Use internal Docker network URLs when running in container
-KEYCLOAK_URL = os.environ.get(
-    "KEYCLOAK_URL", "http://keycloak-e2e:8080"
-)  # Internal Docker network
-KEYCLOAK_REALM = os.environ.get("KEYCLOAK_REALM", "stuf")
-KEYCLOAK_CLIENT_ID = os.environ.get("KEYCLOAK_CLIENT_ID", "stuf-api")
+# OIDC configuration — use discovery to find the token endpoint so the fixtures
+# are provider-agnostic (works with both Keycloak and Zitadel).
+OIDC_ISSUER_URL = os.environ.get("OIDC_ISSUER_URL", "http://keycloak-e2e:8080/realms/stuf")
+
+# Scopes for user (password grant) and service account (client_credentials) tokens.
+# Override these env vars when running against Zitadel.  Keycloak defaults use the
+# stuf:access scope; Zitadel requires project-audience and role scopes instead.
+OIDC_USER_SCOPES = os.environ.get("OIDC_USER_SCOPES", "openid stuf:access")
+OIDC_SERVICE_ACCOUNT_SCOPES = os.environ.get("OIDC_SERVICE_ACCOUNT_SCOPES", "stuf:access")
+
+# SPA client ID for the password-grant user fixture.
+OIDC_SPA_CLIENT_ID = os.environ.get("OIDC_SPA_CLIENT_ID", "stuf-spa")
+
+# Service-account credentials — written to /bootstrap/generated.env by zitadel-init
+# for the Zitadel profile; defaults match the Keycloak realm-export.json fixture.
+OIDC_SERVICE_ACCOUNT_CLIENT_ID = os.environ.get(
+    "OIDC_SERVICE_ACCOUNT_CLIENT_ID",
+    os.environ.get("ZITADEL_BACKUP_SERVICE_CLIENT_ID", "backup-service"),
+)
+OIDC_SERVICE_ACCOUNT_CLIENT_SECRET = os.environ.get(
+    "OIDC_SERVICE_ACCOUNT_CLIENT_SECRET",
+    os.environ.get("ZITADEL_BACKUP_SERVICE_CLIENT_SECRET", "backup-service-secret"),
+)
+
+_token_endpoint: str | None = None
+
+
+def _get_token_endpoint() -> str:
+    """Fetch the token endpoint from OIDC discovery (cached)."""
+    global _token_endpoint
+    if not _token_endpoint:
+        try:
+            resp = requests.get(
+                f"{OIDC_ISSUER_URL}/.well-known/openid-configuration", timeout=10
+            )
+            resp.raise_for_status()
+            _token_endpoint = resp.json()["token_endpoint"]
+        except Exception:
+            # Fallback for backwards compatibility when discovery is not reachable
+            _token_endpoint = (
+                f"{OIDC_ISSUER_URL}/protocol/openid-connect/token"
+            )
+    return _token_endpoint
 
 
 @pytest.fixture
 def real_keycloak_token(ensure_services_ready):  # noqa: F811
-    """Get a real token from Keycloak using password grant for a test user"""
+    """Get a real user token using the password grant."""
 
-    token_url = f"{KEYCLOAK_URL}/realms/{KEYCLOAK_REALM}/protocol/openid-connect/token"
-
-    # Use password grant with test user for E2E tests
     data = {
         "grant_type": "password",
-        "client_id": "stuf-spa",  # Use SPA client for user authentication
+        "client_id": OIDC_SPA_CLIENT_ID,
         "username": "testuser",
         "password": "password",
-        "scope": "openid stuf:access",
+        "scope": OIDC_USER_SCOPES,
     }
 
-    response = requests.post(token_url, data=data)
+    response = requests.post(_get_token_endpoint(), data=data)
 
     if response.status_code != 200:
-        pytest.skip(f"Could not get token from Keycloak: {response.text}")
+        pytest.skip(f"Could not get user token from IDP: {response.text}")
 
-    token_data = response.json()
-    access_token = token_data["access_token"]
-
-    return access_token
+    return response.json()["access_token"]
 
 
 @pytest.fixture
@@ -68,28 +98,22 @@ def e2e_client():
 
 @pytest.fixture
 def limited_keycloak_token(ensure_services_ready):  # noqa: F811
-    """Get a token for a user with limited permissions"""
+    """Get a token for a user with limited permissions."""
 
-    token_url = f"{KEYCLOAK_URL}/realms/{KEYCLOAK_REALM}/protocol/openid-connect/token"
-
-    # Use limiteduser which should have limited permissions
     data = {
         "grant_type": "password",
-        "client_id": "stuf-spa",
+        "client_id": OIDC_SPA_CLIENT_ID,
         "username": "limiteduser",
         "password": "password",
-        "scope": "openid stuf:access",
+        "scope": OIDC_USER_SCOPES,
     }
 
-    response = requests.post(token_url, data=data)
+    response = requests.post(_get_token_endpoint(), data=data)
 
     if response.status_code != 200:
-        pytest.skip(f"Could not get limited token from Keycloak: {response.text}")
+        pytest.skip(f"Could not get limited user token from IDP: {response.text}")
 
-    token_data = response.json()
-    access_token = token_data["access_token"]
-
-    return access_token
+    return response.json()["access_token"]
 
 
 @pytest.fixture
@@ -108,29 +132,23 @@ def e2e_limited_client(e2e_client, limited_keycloak_token):
 
 @pytest.fixture
 def service_account_token(ensure_services_ready):  # noqa: F811
-    """Get a real service account token from Keycloak using client credentials"""
+    """Get a real service account token using the client credentials grant."""
 
-    token_url = f"{KEYCLOAK_URL}/realms/{KEYCLOAK_REALM}/protocol/openid-connect/token"
-
-    # Use client credentials grant for service account
     data = {
         "grant_type": "client_credentials",
-        "client_id": "backup-service",
-        "client_secret": "backup-service-secret",
-        "scope": "stuf:access",
+        "client_id": OIDC_SERVICE_ACCOUNT_CLIENT_ID,
+        "client_secret": OIDC_SERVICE_ACCOUNT_CLIENT_SECRET,
+        "scope": OIDC_SERVICE_ACCOUNT_SCOPES,
     }
 
-    response = requests.post(token_url, data=data)
+    response = requests.post(_get_token_endpoint(), data=data)
 
     if response.status_code != 200:
         pytest.skip(
-            f"Could not get service account token from Keycloak: {response.text}"
+            f"Could not get service account token from IDP: {response.text}"
         )
 
-    token_data = response.json()
-    access_token = token_data["access_token"]
-
-    return access_token
+    return response.json()["access_token"]
 
 
 @pytest.fixture

--- a/api/tests/e2e/test_auth_e2e.py
+++ b/api/tests/e2e/test_auth_e2e.py
@@ -11,7 +11,7 @@ from api.auth.middleware import (
 
 @pytest.mark.e2e
 class TestAuthenticationE2E:
-    """True end-to-end authentication tests using real Keycloak"""
+    """True end-to-end authentication tests using the active OIDC provider"""
 
     def test_oauth2_configuration(self):
         """Test that OAuth2 scheme is properly configured"""
@@ -23,8 +23,8 @@ class TestAuthenticationE2E:
         assert OIDC_ISSUER_URL is not None
         assert len(OIDC_VALID_AUDIENCES) > 0
 
-    def test_token_validation_with_real_keycloak(self, real_keycloak_token):
-        """Test token validation against real Keycloak instance"""
+    def test_token_validation_with_real_idp(self, real_keycloak_token):
+        """Test token validation against the active OIDC provider"""
 
         # This should work with a real token from the fixture
         token_info = verify_jwt_token(real_keycloak_token)

--- a/api/tests/e2e/test_service_account_e2e.py
+++ b/api/tests/e2e/test_service_account_e2e.py
@@ -10,11 +10,17 @@ from fastapi.testclient import TestClient
 
 from api.auth.middleware import get_current_principal, verify_jwt_token
 from api.main import app
+from api.tests.e2e.conftest import (
+    OIDC_SERVICE_ACCOUNT_CLIENT_ID,
+    OIDC_SERVICE_ACCOUNT_CLIENT_SECRET,
+    OIDC_SERVICE_ACCOUNT_SCOPES,
+    _get_token_endpoint,
+)
 
 
 @pytest.mark.e2e
 class TestServiceAccountE2E:
-    """End-to-end tests for service account authentication using real Keycloak"""
+    """End-to-end tests for service account authentication using the active OIDC provider"""
 
     def test_service_account_token_validation(self, service_account_token):
         """Test that service account token is valid and properly structured"""
@@ -24,11 +30,7 @@ class TestServiceAccountE2E:
         assert token_info is not None
         # Service account tokens should have client_id/azp
         assert "azp" in token_info or "client_id" in token_info
-        # Real Keycloak service accounts DO have preferred_username (e.g., "service-account-backup-service")
-        assert "preferred_username" in token_info
-        # But the preferred_username should start with "service-account-" for service accounts
-        preferred_username = token_info.get("preferred_username", "")
-        assert preferred_username.startswith("service-account-")
+        # Service accounts are identified by azp/sub, not by preferred_username prefix
         assert "iss" in token_info  # Issuer
         assert "exp" in token_info  # Expiration
         assert "collections" in token_info  # Collection permissions
@@ -109,8 +111,6 @@ class TestServiceAccountE2E:
 
         assert isinstance(principal, ServiceAccount)
         assert principal.client_id == "backup-service"
-        # Service account tokens from Keycloak don't include realm roles by default
-        # Authorization is based on collections, not roles
         assert isinstance(principal.roles, list)
 
     def test_service_account_vs_user_token_difference(
@@ -123,14 +123,9 @@ class TestServiceAccountE2E:
 
         # Service account token characteristics
         assert "azp" in service_payload or "client_id" in service_payload
-        # Service accounts DO have preferred_username, but it starts with "service-account-"
-        service_username = service_payload.get("preferred_username", "")
-        assert service_username.startswith("service-account-")
 
         # User token characteristics
         assert "preferred_username" in user_payload
-        user_username = user_payload.get("preferred_username", "")
-        assert not user_username.startswith("service-account-")
         assert user_payload.get("azp") != service_payload.get("azp")
 
         # Both should have standard JWT claims
@@ -150,19 +145,15 @@ class TestServiceAccountE2E:
 
     def test_service_account_authentication_flow_e2e(self, ensure_services_ready):
         """Test complete service account authentication flow from token request to API access"""
-        # Step 1: Get service account token via client credentials
-        token_url = (
-            f"http://keycloak-e2e:8080/realms/stuf/protocol/openid-connect/token"
-        )
-
+        # Step 1: Get service account token via client credentials (provider-agnostic)
         data = {
             "grant_type": "client_credentials",
-            "client_id": "backup-service",
-            "client_secret": "backup-service-secret",
-            "scope": "stuf:access",
+            "client_id": OIDC_SERVICE_ACCOUNT_CLIENT_ID,
+            "client_secret": OIDC_SERVICE_ACCOUNT_CLIENT_SECRET,
+            "scope": OIDC_SERVICE_ACCOUNT_SCOPES,
         }
 
-        token_response = requests.post(token_url, data=data)
+        token_response = requests.post(_get_token_endpoint(), data=data)
         assert token_response.status_code == 200
 
         token_data = token_response.json()

--- a/api/tests/fixtures/test_data.py
+++ b/api/tests/fixtures/test_data.py
@@ -55,7 +55,7 @@ SAMPLE_METADATA = {
     },
 }
 
-# Sample Keycloak token responses
+# Sample OIDC token responses
 SAMPLE_TOKEN_RESPONSES = {
     "valid": {
         "active": True,

--- a/api/tests/integration/conftest.py
+++ b/api/tests/integration/conftest.py
@@ -211,6 +211,64 @@ def mock_jwt_verification():
                 "exp": int(time.time()) + 3600,
                 "iat": int(time.time()),
             }
+        # --- Zitadel-shaped tokens ---
+        # Roles in urn:zitadel:iam:org:project:roles (dict), issuer has no realm path.
+        elif token == "zitadel-user-integration-test-token":
+            return {
+                "sub": "testuser-zitadel-id",
+                "preferred_username": "testuser@example.com",
+                "email": "testuser@example.com",
+                "given_name": "Test",
+                "family_name": "User",
+                "azp": "abc123-spa-client-id",  # Zitadel auto-generated SPA client ID
+                "scope": "openid profile email urn:zitadel:iam:org:project:roles urn:zitadel:iam:org:project:id:12345:aud",
+                "urn:zitadel:iam:org:project:roles": {
+                    "project-participant": {"orgId": "orgDomain"},
+                    "collection-test": {"orgId": "orgDomain"},
+                },
+                "collections": {"test": ["read", "write", "delete"]},
+                "aud": ["abc123-spa-client-id", "12345"],
+                "iss": "http://localhost:8080",
+                "exp": int(time.time()) + 3600,
+                "iat": int(time.time()),
+            }
+        elif token == "zitadel-admin-integration-test-token":
+            return {
+                "sub": "admin-zitadel-id",
+                "preferred_username": "admin@example.com",
+                "email": "admin@example.com",
+                "given_name": "Admin",
+                "family_name": "User",
+                "azp": "abc123-spa-client-id",
+                "scope": "openid profile email urn:zitadel:iam:org:project:roles urn:zitadel:iam:org:project:id:12345:aud",
+                "urn:zitadel:iam:org:project:roles": {
+                    "admin": {"orgId": "orgDomain"},
+                    "collection-test": {"orgId": "orgDomain"},
+                    "collection-restricted": {"orgId": "orgDomain"},
+                },
+                "collections": {
+                    "test": ["read", "write", "delete"],
+                    "restricted": ["read", "write", "delete"],
+                },
+                "aud": ["abc123-spa-client-id", "12345"],
+                "iss": "http://localhost:8080",
+                "exp": int(time.time()) + 3600,
+                "iat": int(time.time()),
+            }
+        elif token == "zitadel-service-account-integration-test-token":
+            return {
+                "sub": "backup-service",
+                "azp": "backup-service",
+                "scope": "openid urn:zitadel:iam:org:project:id:12345:aud",
+                "urn:zitadel:iam:org:project:roles": {
+                    "service": {"orgId": "orgDomain"},
+                },
+                "collections": {"test": ["read", "write", "delete"]},
+                "aud": ["backup-service", "12345"],
+                "iss": "http://localhost:8080",
+                "exp": int(time.time()) + 3600,
+                "iat": int(time.time()),
+            }
         return None
 
     with patch("auth.middleware.verify_jwt_token", side_effect=mock_verify_jwt_token):
@@ -245,3 +303,21 @@ def service_account_headers():
 def limited_service_account_headers():
     """Headers with limited service account authentication token (no access to test collection)"""
     return {"Authorization": "Bearer limited-service-account-integration-test-token"}
+
+
+@pytest.fixture
+def zitadel_authenticated_headers():
+    """Headers with Zitadel-shaped user token (project roles claim, no realm_access)"""
+    return {"Authorization": "Bearer zitadel-user-integration-test-token"}
+
+
+@pytest.fixture
+def zitadel_admin_headers():
+    """Headers with Zitadel-shaped admin token"""
+    return {"Authorization": "Bearer zitadel-admin-integration-test-token"}
+
+
+@pytest.fixture
+def zitadel_service_account_headers():
+    """Headers with Zitadel-shaped service account token (project roles claim)"""
+    return {"Authorization": "Bearer zitadel-service-account-integration-test-token"}

--- a/docs/technical/service-accounts.md
+++ b/docs/technical/service-accounts.md
@@ -24,24 +24,30 @@ Service accounts provide a way for automated systems, scripts, and applications 
 
 ## Setting Up Service Accounts
 
-### 1. Create Service Account in Keycloak
+### 1. Create Service Account in the IDP
 
-1. Access Keycloak Admin Console: `http://localhost:8080/admin`
-2. Navigate to your realm (e.g., "stuf")
-3. Go to **Clients** → **Create Client**
-4. Configure the client:
+**Keycloak** (default dev profile):
+1. Access Admin Console: `http://localhost:8080/admin`
+2. Navigate to your realm (e.g., "stuf") → **Clients** → **Create Client**
+3. Configure the client:
    - **Client Type**: OpenID Connect
    - **Client ID**: `your-service-name` (e.g., `backup-service`)
    - **Client Authentication**: On
-   - **Authorization**: Off
    - **Authentication Flow**: Service accounts roles
+
+**Zitadel** (zitadel dev profile):
+1. Add a machine user entry under `machine_users:` in `docker/zitadel-init/dev/instance.yaml`
+2. Re-run `docker compose --profile zitadel up -d`; the `zitadel-init` container will
+   provision the machine user and write its credentials to `/bootstrap/generated.env`.
 
 ### 2. Configure Service Account Permissions
 
-Add collections permissions to the service account's JWT claims:
+Add collections permissions to the service account. In the dev environment these are
+set via the `collections:` key in the IDP fixture file.  For the `collections` claim
+to appear in access tokens, the STUF `injectCollections` Action (Zitadel) or the
+`stuf:access` client scope mapper (Keycloak) must be configured.
 
-1. In Keycloak, go to **Clients** → Your Service Account → **Client Scopes**
-2. Add a custom claim for collections:
+Example collections value:
    ```json
    {
      "docs": ["read", "write", "delete"],
@@ -62,8 +68,11 @@ Add appropriate roles to the service account:
 ### Getting an Access Token
 
 ```bash
+# Discover the token endpoint from OIDC discovery
+TOKEN_ENDPOINT=$(curl -s http://localhost:8080/.well-known/openid-configuration | jq -r .token_endpoint)
+
 # Request token using client credentials
-curl -X POST "http://localhost:8080/realms/stuf/protocol/openid-connect/token" \
+curl -X POST "$TOKEN_ENDPOINT" \
   -H "Content-Type: application/x-www-form-urlencoded" \
   -d "grant_type=client_credentials" \
   -d "client_id=backup-service" \
@@ -212,7 +221,7 @@ Service accounts can have OAuth2 scopes that further restrict their capabilities
 # Service account credentials
 export BACKUP_SERVICE_CLIENT_ID="backup-service"
 export BACKUP_SERVICE_CLIENT_SECRET="your-secret-here"
-export KEYCLOAK_TOKEN_URL="http://localhost:8080/realms/stuf/protocol/openid-connect/token"
+export OIDC_ISSUER_URL="http://localhost:8080"   # no realm path for Zitadel
 export STUF_API_URL="http://localhost:8000/api"
 ```
 
@@ -222,7 +231,7 @@ export STUF_API_URL="http://localhost:8000/api"
 
 1. **Token validation fails**
    - Check client_id and client_secret
-   - Verify Keycloak realm configuration
+   - Verify IDP configuration and OIDC discovery endpoint
    - Ensure service account has proper roles
 
 2. **Permission denied errors**

--- a/spa/src/hooks/user/useUser.ts
+++ b/spa/src/hooks/user/useUser.ts
@@ -18,7 +18,7 @@ export function useUser(): User | null {
     const username = (profile?.preferred_username as string) || "";
 
     return {
-      username, // Keycloak preferred_username - matches backend user.username
+      username, // standard OIDC preferred_username - matches backend user.username
       name:
         profile?.given_name && profile?.family_name
           ? `${profile.given_name} ${profile.family_name}`

--- a/tasks/0001-support-zitadel-as-oidc-provider.md
+++ b/tasks/0001-support-zitadel-as-oidc-provider.md
@@ -322,6 +322,14 @@ metadata for `collections`).
    `/realms/{realm}/protocol/openid-connect/token`). Add an `OIDC_PROVIDER`
    env discriminator the fixture can use to pick scopes correctly
    (`stuf:access` for Keycloak vs the audience+roles scopes for Zitadel).
+   **Note:** Zitadel v4 does not support the Resource Owner Password
+   Credentials (ROPC / password grant) for OIDC applications — the SPA
+   app is created with `OIDC_GRANT_TYPE_AUTHORIZATION_CODE` and
+   `OIDC_GRANT_TYPE_REFRESH_TOKEN` only. The `real_keycloak_token` and
+   `limited_keycloak_token` fixtures therefore cannot obtain user tokens
+   against Zitadel and will `pytest.skip`. ROPC is test-only (the SPA
+   uses the authorization code PKCE flow); no production functionality is
+   affected. See open question 9 for the resolution path.
 
 8. **`api/tests/integration/conftest.py` +
    `api/tests/fixtures/test_data.py`** — the mocked token payloads currently
@@ -476,6 +484,21 @@ These need decisions or upstream investigation before implementation:
    `OIDC_BASE_URL` must use `localhost` rather than `zitadel`.
    `zitadel-login` uses `PORT` env var to bind on 8090 instead of the
    default 3000.
+
+9. **API e2e user-token acquisition under Zitadel.** The `real_keycloak_token`
+   and `limited_keycloak_token` API e2e fixtures use the ROPC password grant,
+   which Zitadel v4 does not support for OIDC applications. Options:
+   - (a) Add e2e machine users to `instance.yaml` that mirror each test
+     human user's roles and collections, then use `client_credentials` to
+     obtain tokens for them — subject to confirming that the
+     `preAccessTokenCreation` Action fires for client_credentials flows
+     (open question 1 note).
+   - (b) Use the Zitadel session API to authenticate a human user
+     server-side and exchange the session for tokens (more complex, closer
+     to a real user flow).
+   Option (a) is lower friction; it reuses the same fixture shape and only
+   requires new `instance.yaml` entries and corresponding `generated.env`
+   writes from `provision.py`.
 
 ## Suggested implementation order
 

--- a/tests/e2e-browser/config.py
+++ b/tests/e2e-browser/config.py
@@ -5,7 +5,19 @@ import os
 # Test environment URLs - Docker container defaults
 SPA_URL = os.getenv("SPA_URL", "http://spa-e2e:3000")
 API_URL = os.getenv("API_URL", "http://api-e2e:8000")
-KEYCLOAK_URL = os.getenv("KEYCLOAK_URL", "http://keycloak-e2e:8080")
+
+# IDP base URL for service health checks.
+IDP_URL = os.getenv("IDP_URL", "http://keycloak-e2e:8080")
+
+# OIDC discovery base URL (issuer as seen by clients).
+# For Keycloak: http://<host>/realms/<realm>
+# For Zitadel:  http://<host>  (no realm path)
+OIDC_ISSUER_URL = os.getenv("OIDC_ISSUER_URL", f"{IDP_URL}/realms/stuf")
+
+# Login UI base URL — for Zitadel the login screens are served by a separate
+# zitadel-login container (default port 8090) rather than by the main IDP.
+# Empty string means the IDP itself serves the login UI (Keycloak default).
+IDP_LOGIN_URL = os.getenv("IDP_LOGIN_URL", "")
 
 # Playwright configuration
 PLAYWRIGHT_HEADLESS = os.getenv("PLAYWRIGHT_HEADLESS", "true")

--- a/tests/e2e-browser/conftest.py
+++ b/tests/e2e-browser/conftest.py
@@ -9,7 +9,7 @@ from playwright.sync_api import sync_playwright
 try:
     from config import (
         API_URL,
-        KEYCLOAK_URL,
+        IDP_URL,
         PLAYWRIGHT_HEADLESS,
         PLAYWRIGHT_SLOW_MO,
         SPA_HOST,
@@ -21,7 +21,7 @@ except Exception:
     # Fallback values
     BASE_URL = "http://spa-e2e:3000"
     API_URL = "http://api-e2e:8000"
-    KEYCLOAK_URL = "http://keycloak-e2e:8080"
+    IDP_URL = "http://keycloak-e2e:8080"
     SPA_HOST = "spa-e2e:3000"
 
 STORAGE_STATE_FILE = Path(__file__).parent / "auth-storage-state.json"
@@ -117,9 +117,9 @@ def authenticated_page(page):
         if login_button.is_visible():
             login_button.click()
 
-            # Wait for redirect to Keycloak
-            page.wait_for_url(
-                f"{KEYCLOAK_URL}/realms/stuf/protocol/openid-connect/auth*",
+            # Wait until we leave the SPA (redirect to IDP)
+            page.wait_for_function(
+                f"() => !window.location.href.includes('{SPA_HOST}')",
                 timeout=10000,
             )
         else:
@@ -198,7 +198,7 @@ def app_urls():
     return {
         "spa": BASE_URL,
         "api": API_URL,
-        "keycloak": KEYCLOAK_URL,
+        "idp": IDP_URL,
     }
 
 

--- a/tests/e2e-browser/docker-compose.e2e-browser.yml
+++ b/tests/e2e-browser/docker-compose.e2e-browser.yml
@@ -108,10 +108,11 @@ services:
       # API configuration (internal Docker network URL)
       - API_URL=http://api-e2e:8000
 
-      # Keycloak configuration (internal Docker network URL)
-      - KEYCLOAK_URL=http://keycloak-e2e:8080
-      - KEYCLOAK_REALM=stuf
-      - KEYCLOAK_CLIENT_ID=stuf-spa
+      # OIDC authority passed directly so docker-entrypoint.sh needs no realm
+      # path assembly. For Keycloak the value is keycloakUrl/realms/realm;
+      # for Zitadel it is just the issuer URL (no realm segment).
+      - OIDC_AUTHORITY=http://keycloak-e2e:8080/realms/stuf
+      - OIDC_CLIENT_ID=stuf-spa
     depends_on:
       - api-e2e
     networks:
@@ -138,12 +139,11 @@ services:
       # Use internal Docker network URLs
       - SPA_URL=http://spa-e2e:3000
       - API_URL=http://api-e2e:8000
-      - KEYCLOAK_URL=http://keycloak-e2e:8080
+      - IDP_URL=http://keycloak-e2e:8080
       - MINIO_URL=http://minio-e2e:9000
-      # API E2E tests: OIDC vars for middleware, KEYCLOAK_* vars for token fixtures
+      # OIDC configuration (provider-agnostic)
       - OIDC_ISSUER_URL=http://keycloak-e2e:8080/realms/stuf
       - OIDC_VALID_AUDIENCES=stuf-api,stuf-spa
-      - KEYCLOAK_REALM=stuf
       # MinIO configuration for API E2E tests
       - MINIO_ENDPOINT=minio-e2e:9000
       - MINIO_ROOT_USER=minioadmin

--- a/tests/e2e-browser/helpers/service_health.py
+++ b/tests/e2e-browser/helpers/service_health.py
@@ -7,7 +7,7 @@ import time
 import httpx
 import pytest
 
-from config import SPA_URL, API_URL, KEYCLOAK_URL
+from config import SPA_URL, API_URL, IDP_URL
 
 
 def check_services_ready():
@@ -16,7 +16,7 @@ def check_services_ready():
     services = [
         (f"{API_URL}/api/health", "API"),
         (f"{SPA_URL}", "SPA"),
-        (f"{KEYCLOAK_URL}", "Keycloak"),
+        (f"{IDP_URL}", "IDP"),
     ]
 
     for url, name in services:

--- a/tests/e2e-browser/pages/login_page.py
+++ b/tests/e2e-browser/pages/login_page.py
@@ -1,94 +1,117 @@
-"""Login Page Object Model for Keycloak authentication."""
+"""Login Page Object Model supporting both Keycloak and Zitadel login flows."""
 
-from config import KEYCLOAK_URL, SPA_HOST
+from config import IDP_LOGIN_URL, OIDC_ISSUER_URL, SPA_HOST
 from playwright.sync_api import Page
 
 from .base_page import BasePage
 
 
 class LoginPage(BasePage):
-    """Page object for Keycloak login interactions."""
+    """Page object for OIDC login interactions.
+
+    Supports two providers:
+    - Keycloak: single-step form (username + password on one page).
+    - Zitadel: two-step form (login-name page → Next → password page → Sign in).
+
+    Provider detection is automatic based on the current page URL after the OIDC
+    redirect:  Keycloak login URLs contain ``/realms/``, Zitadel login URLs contain
+    ``/ui/v2/login/``.
+    """
 
     def __init__(self, page: Page):
         super().__init__(page)
-        self.keycloak_url = KEYCLOAK_URL
 
-    # Selectors
-    USERNAME_INPUT = 'input[name="username"]'
-    PASSWORD_INPUT = 'input[name="password"]'
-    LOGIN_BUTTON = 'button[type="submit"], input[type="submit"]'
-    ERROR_MESSAGE = ".alert-error, #input-error, .kc-feedback-text"
-    FORGOT_PASSWORD_LINK = 'a[href*="forgot-credentials"]'
-    REGISTER_LINK = 'a[href*="registration"]'
+    # ── Keycloak selectors ─────────────────────────────────────────────────────
+    KC_USERNAME_INPUT = 'input[name="username"]'
+    KC_PASSWORD_INPUT = 'input[name="password"]'
+    KC_LOGIN_BUTTON = 'button[type="submit"], input[type="submit"]'
+    KC_ERROR_MESSAGE = ".alert-error, #input-error, .kc-feedback-text"
+
+    # ── Zitadel-login selectors (ghcr.io/zitadel/zitadel-login v4) ────────────
+    # The Zitadel login UI is a Next.js app served at IDP_LOGIN_URL (port 8090
+    # by default). It uses a two-step flow: login-name first, then password.
+    # Selectors verified against zitadel-login v4.14.0 DOM.
+    ZD_LOGINNAME_INPUT = 'input[name="loginName"]'
+    ZD_PASSWORD_INPUT = 'input[name="password"]'
+    ZD_SUBMIT_BUTTON = 'button[type="submit"]'
+    ZD_ERROR_MESSAGE = '[data-testid="error"], .error'
+
+    def _is_zitadel(self) -> bool:
+        """Return True when the current URL belongs to the Zitadel login UI."""
+        return "/ui/v2/login/" in self.page.url
 
     def wait_for_login_form(self, timeout: int = 30000) -> None:
-        """Wait for the Keycloak login form to appear."""
-        # Wait for redirect to Keycloak
-        self.page.wait_for_url(
-            f"{self.keycloak_url}/realms/stuf/protocol/openid-connect/auth*",
-            timeout=timeout,
-        )
-
-        # Wait for page to fully load (CSS/JS)
+        """Wait for the login form to appear, regardless of provider."""
         self.page.wait_for_load_state("networkidle", timeout=15000)
+        # Give JavaScript time to render the form
+        self.page.wait_for_timeout(2000)
 
-        # Give extra time for JavaScript to execute and render form
-        self.page.wait_for_timeout(3000)
-
-        # Wait for login form elements
+        # Wait for whichever username / login-name input appears (Keycloak or Zitadel)
+        combined_selector = f"{self.KC_USERNAME_INPUT}, {self.ZD_LOGINNAME_INPUT}"
         try:
-            self.wait_for_selector(self.USERNAME_INPUT, timeout=15000)
+            self.wait_for_selector(combined_selector, timeout=timeout)
         except Exception as e:
-            # Take a screenshot for debugging if login form fails to load
             try:
-                screenshot_path = "/app/reports/debug-keycloak-login.png"
-                self.page.screenshot(path=screenshot_path)
+                self.page.screenshot(path="/app/reports/debug-login.png")
             except Exception:
                 pass
             raise RuntimeError(
                 f"Login form failed to load. Current URL: {self.page.url}"
             ) from e
 
-        self.wait_for_selector(self.PASSWORD_INPUT, timeout=10000)
-        self.wait_for_selector(self.LOGIN_BUTTON, timeout=10000)
+        if not self._is_zitadel():
+            self.wait_for_selector(self.KC_PASSWORD_INPUT, timeout=10000)
+            self.wait_for_selector(self.KC_LOGIN_BUTTON, timeout=10000)
 
     def fill_username(self, username: str) -> None:
-        """Fill the username field."""
-        self.fill_input(self.USERNAME_INPUT, username)
+        """Fill the username / login-name field."""
+        selector = (
+            self.ZD_LOGINNAME_INPUT if self._is_zitadel() else self.KC_USERNAME_INPUT
+        )
+        self.fill_input(selector, username)
 
     def fill_password(self, password: str) -> None:
         """Fill the password field."""
-        self.fill_input(self.PASSWORD_INPUT, password)
+        selector = self.ZD_PASSWORD_INPUT if self._is_zitadel() else self.KC_PASSWORD_INPUT
+        self.fill_input(selector, password)
 
     def click_login(self) -> None:
-        """Click the login button."""
-        self.click_element(self.LOGIN_BUTTON)
+        """Click the primary submit button."""
+        selector = self.ZD_SUBMIT_BUTTON if self._is_zitadel() else self.KC_LOGIN_BUTTON
+        self.click_element(selector)
 
     def login(self, username: str, password: str) -> None:
-        """Perform complete login flow."""
+        """Perform the complete login flow for whichever provider is active."""
         self.wait_for_login_form()
-        self.fill_username(username)
-        self.fill_password(password)
-        self.click_login()
 
-        # Wait for redirect back to the SPA (more flexible)
+        if self._is_zitadel():
+            # Step 1: enter login name and advance
+            self.fill_input(self.ZD_LOGINNAME_INPUT, username)
+            self.click_element(self.ZD_SUBMIT_BUTTON)
+            # Step 2: wait for password field and submit
+            self.wait_for_selector(self.ZD_PASSWORD_INPUT, timeout=10000)
+            self.fill_input(self.ZD_PASSWORD_INPUT, password)
+            self.click_element(self.ZD_SUBMIT_BUTTON)
+        else:
+            self.fill_username(username)
+            self.fill_password(password)
+            self.click_login()
+
+        # Wait for redirect back to the SPA
         try:
-            # Wait for navigation away from Keycloak
             self.page.wait_for_url(f"*{SPA_HOST}*", timeout=15000)
         except Exception:
-            # Maybe already redirected - check current URL
             current_url = self.get_current_url()
             if SPA_HOST not in current_url:
                 raise RuntimeError(
                     f"Login failed - not redirected to SPA. Current URL: {current_url}"
                 )
 
-        # Give time for any additional redirects or processing
         self.page.wait_for_timeout(2000)
 
     def login_with_admin_user(self) -> None:
         """Login with default admin user credentials."""
-        self.login("admin@example.com", "password")
+        self.login("admin@example.com", "Password1!" if self._is_zitadel() else "password")
 
     def login_with_test_user(self) -> None:
         """Login with default test user credentials."""
@@ -100,79 +123,78 @@ class LoginPage(BasePage):
 
     def assert_login_form_visible(self) -> None:
         """Assert that the login form is visible."""
-        self.assert_element_visible(
-            self.USERNAME_INPUT, "Username input should be visible"
-        )
-        self.assert_element_visible(
-            self.PASSWORD_INPUT, "Password input should be visible"
-        )
-        self.assert_element_visible(self.LOGIN_BUTTON, "Login button should be visible")
+        if self._is_zitadel():
+            self.assert_element_visible(
+                self.ZD_LOGINNAME_INPUT, "Login name input should be visible"
+            )
+        else:
+            self.assert_element_visible(
+                self.KC_USERNAME_INPUT, "Username input should be visible"
+            )
+            self.assert_element_visible(
+                self.KC_PASSWORD_INPUT, "Password input should be visible"
+            )
+            self.assert_element_visible(
+                self.KC_LOGIN_BUTTON, "Login button should be visible"
+            )
 
     def assert_error_message_visible(self, expected_message: str = None) -> None:
         """Assert that an error message is displayed."""
-        self.assert_element_visible(
-            self.ERROR_MESSAGE, "Error message should be visible"
-        )
+        selector = self.ZD_ERROR_MESSAGE if self._is_zitadel() else self.KC_ERROR_MESSAGE
+        self.assert_element_visible(selector, "Error message should be visible")
         if expected_message:
-            self.assert_text_content(self.ERROR_MESSAGE, expected_message)
+            self.assert_text_content(selector, expected_message)
 
-    def assert_on_keycloak_page(self) -> None:
-        """Assert that we are on a Keycloak page."""
+    def assert_on_idp_page(self) -> None:
+        """Assert that we are on the IDP login page."""
         current_url = self.get_current_url()
-        assert self.keycloak_url in current_url, (
-            f"Should be on Keycloak page, but URL is: {current_url}"
+        on_page = (
+            "/ui/v2/login/" in current_url
+            or "/realms/" in current_url
         )
+        assert on_page, f"Should be on IDP login page, but URL is: {current_url}"
 
     def is_login_form_visible(self) -> bool:
         """Check if the login form is currently visible."""
+        if self._is_zitadel():
+            return self.is_visible(self.ZD_LOGINNAME_INPUT)
         return (
-            self.is_visible(self.USERNAME_INPUT)
-            and self.is_visible(self.PASSWORD_INPUT)
-            and self.is_visible(self.LOGIN_BUTTON)
+            self.is_visible(self.KC_USERNAME_INPUT)
+            and self.is_visible(self.KC_PASSWORD_INPUT)
+            and self.is_visible(self.KC_LOGIN_BUTTON)
         )
-
-    def clear_username(self) -> None:
-        """Clear the username field."""
-        self.page.fill(self.USERNAME_INPUT, "")
-
-    def clear_password(self) -> None:
-        """Clear the password field."""
-        self.page.fill(self.PASSWORD_INPUT, "")
-
-    def click_forgot_password(self) -> None:
-        """Click the forgot password link if available."""
-        if self.is_visible(self.FORGOT_PASSWORD_LINK):
-            self.click_element(self.FORGOT_PASSWORD_LINK)
-
-    def click_register(self) -> None:
-        """Click the register link if available."""
-        if self.is_visible(self.REGISTER_LINK):
-            self.click_element(self.REGISTER_LINK)
-
-    def get_page_title(self) -> str:
-        """Get the current page title."""
-        return self.page.title()
-
-    def wait_for_redirect_to_spa(self, timeout: int = 30000) -> None:
-        """Wait for redirect back to the SPA after successful login."""
-        self.wait_for_url_contains(SPA_HOST, timeout=timeout)
-        # Wait for the page to load completely
-        self.wait_for_network_idle()
 
     def attempt_invalid_login(
         self, username: str = "invalid", password: str = "wrong"
     ) -> None:
         """Attempt login with invalid credentials."""
         self.wait_for_login_form()
-        self.fill_username(username)
-        self.fill_password(password)
-        self.click_login()
-        # Don't wait for redirect since it should fail
+        if self._is_zitadel():
+            self.fill_input(self.ZD_LOGINNAME_INPUT, username)
+            self.click_element(self.ZD_SUBMIT_BUTTON)
+            try:
+                self.wait_for_selector(self.ZD_PASSWORD_INPUT, timeout=5000)
+                self.fill_input(self.ZD_PASSWORD_INPUT, password)
+                self.click_element(self.ZD_SUBMIT_BUTTON)
+            except Exception:
+                pass  # Username step may already have shown the error
+        else:
+            self.fill_username(username)
+            self.fill_password(password)
+            self.click_login()
+
+    def wait_for_redirect_to_spa(self, timeout: int = 30000) -> None:
+        """Wait for redirect back to the SPA after successful login."""
+        self.wait_for_url_contains(SPA_HOST, timeout=timeout)
+        self.wait_for_network_idle()
 
     def get_username_input_value(self) -> str:
-        """Get the current value of the username input."""
-        return self.page.input_value(self.USERNAME_INPUT)
+        """Get the current value of the username / login-name input."""
+        selector = (
+            self.ZD_LOGINNAME_INPUT if self._is_zitadel() else self.KC_USERNAME_INPUT
+        )
+        return self.page.input_value(selector)
 
-    def get_password_input_value(self) -> str:
-        """Get the current value of the password input."""
-        return self.page.input_value(self.PASSWORD_INPUT)
+    def get_page_title(self) -> str:
+        """Get the current page title."""
+        return self.page.title()

--- a/tests/e2e-browser/step_definitions/authentication_steps.py
+++ b/tests/e2e-browser/step_definitions/authentication_steps.py
@@ -331,7 +331,7 @@ def see_authentication_error(page: Page, bdd_screenshot_helper):
 def remain_on_login_page(page: Page):
     """Verify still on login page."""
     login_page = LoginPage(page)
-    login_page.assert_on_keycloak_page()
+    login_page.assert_on_idp_page()
     login_page.assert_login_form_visible()
 
 

--- a/tests/e2e-browser/test_smoke.py
+++ b/tests/e2e-browser/test_smoke.py
@@ -2,7 +2,7 @@
 
 import httpx
 import pytest
-from config import API_URL, KEYCLOAK_URL, SPA_HOST, SPA_URL
+from config import API_URL, IDP_URL, SPA_HOST, SPA_URL
 from pages.dashboard_page import DashboardPage
 from pages.login_page import LoginPage
 from playwright.sync_api import Page
@@ -25,11 +25,10 @@ class TestBasicConnectivity:
             assert response.status_code == 200
             assert "STUF" in response.text
 
-        # Test Keycloak basic response
+        # Test IDP basic response
         with httpx.Client() as client:
-            response = client.get(KEYCLOAK_URL, timeout=10.0)
-            # Keycloak may return various status codes, just ensure it responds
-            assert response.status_code < 500  # Any response better than server error
+            response = client.get(IDP_URL, timeout=10.0)
+            assert response.status_code < 500
 
 
 class TestSmokeConnectivity:
@@ -98,10 +97,10 @@ class TestSmokeConnectivity:
         login_button.click()
         dashboard.take_screenshot("02-clicked-login-button")
 
-        # Should redirect to Keycloak
+        # Should redirect to IDP login form
         login_page = LoginPage(page)
         login_page.wait_for_login_form(timeout=15000)
-        login_page.take_screenshot("03-keycloak-login-form")
+        login_page.take_screenshot("03-idp-login-form")
         login_page.assert_login_form_visible()
 
     def test_complete_authentication_flow(self, page: Page):

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -105,54 +105,62 @@ wait_for_services_healthy() {
     return 1
 }
 
-# Wait for Keycloak to be ready by checking its health endpoint
-wait_for_keycloak() {
-    log_info "Waiting for Keycloak to be ready..."
-    
+# Wait for the active identity provider to be ready.
+# Supports both Keycloak (health/ready endpoint + realm discovery) and Zitadel
+# (debug/healthz endpoint + root OIDC discovery).  The IDP_PORT env var selects
+# the host port (default 8180 for e2e; 8080 for the main dev stack).
+wait_for_idp() {
+    local idp_port="${IDP_PORT:-8180}"
+    log_info "Waiting for IDP to be ready on port ${idp_port}..."
+
     local max_attempts=30  # 5 minutes total (30 * 10 seconds)
     local attempt=0
-    
+
     while [ $attempt -lt $max_attempts ]; do
-        # Check if Keycloak health endpoint responds
-        if curl -s -f http://localhost:8180/health/ready > /dev/null 2>&1; then
-            log_success "Keycloak is ready"
+        # Zitadel readiness probe
+        if curl -s -f "http://localhost:${idp_port}/debug/healthz" > /dev/null 2>&1; then
+            log_success "IDP (Zitadel) is ready"
             return 0
         fi
-        
-        # Also check if realm endpoint exists (fallback)
-        if curl -s http://localhost:8180/realms/stuf/.well-known/openid_configuration > /dev/null 2>&1; then
-            log_success "Keycloak realm is accessible"
+        # Keycloak readiness probe
+        if curl -s -f "http://localhost:${idp_port}/health/ready" > /dev/null 2>&1; then
+            log_success "IDP (Keycloak) is ready"
             return 0
         fi
-        
+        # Generic OIDC discovery fallback
+        if curl -s "http://localhost:${idp_port}/.well-known/openid-configuration" > /dev/null 2>&1; then
+            log_success "IDP OIDC discovery is accessible"
+            return 0
+        fi
+
         attempt=$((attempt + 1))
-        log_info "Waiting for Keycloak to be ready... ($attempt/$max_attempts)"
+        log_info "Waiting for IDP to be ready... ($attempt/$max_attempts)"
         sleep 10
     done
-    
-    log_error "Keycloak failed to become ready within 5 minutes"
-    log_info "Checking Keycloak logs for debugging:"
-    docker compose -f "$E2E_DIR/docker-compose.e2e-browser.yml" logs keycloak-e2e --tail=20
+
+    log_error "IDP failed to become ready within 5 minutes"
+    log_info "Checking service logs for debugging:"
+    docker compose -f "$E2E_DIR/docker-compose.e2e-browser.yml" logs --tail=20 2>/dev/null || true
     return 1
 }
 
 # Check if Docker is running and services are available
 check_docker_services() {
     log_info "Checking if Docker services are running..."
-    
+
     # Check if docker-compose services are up
     if ! docker compose -f "$E2E_DIR/docker-compose.e2e-browser.yml" ps --services --filter "status=running" | grep -q .; then
         log_warning "Docker services are not running. Starting them..."
         start_docker_services
-        
-        # Wait specifically for Keycloak to be ready (most critical service)
-        wait_for_keycloak
-        
+
+        # Wait for the IDP to be ready (most critical service)
+        wait_for_idp
+
         # Check if key services are responding
         log_info "Checking other service connectivity..."
         local max_attempts=12
         local attempt=0
-        
+
         while [ $attempt -lt $max_attempts ]; do
             if curl -s http://localhost:8100/api/health > /dev/null && curl -s http://localhost:3100 > /dev/null; then
                 log_success "All services are responding"
@@ -162,12 +170,12 @@ check_docker_services() {
             log_info "Waiting for API and SPA to be ready... ($attempt/$max_attempts)"
             sleep 10
         done
-        
+
         log_warning "Some services may still be starting. Continuing anyway..."
     else
         log_success "Docker services are running"
-        # Even if services are running, verify Keycloak is responding
-        wait_for_keycloak
+        # Even if services are running, verify IDP is responding
+        wait_for_idp
     fi
 }
 


### PR DESCRIPTION
Ref: #85. Follows #89.

## Summary

- **Step 5**: `api/auth/middleware.py` gains `_extract_roles()` (handles both `realm_access.roles` for Keycloak and `urn:zitadel:iam:org:project:roles` for Zitadel) and `OIDC_SPA_CLIENT_ID` env var replacing the hard-coded `"stuf-spa"` in principal discrimination. API e2e fixtures rewritten to use OIDC discovery for the token endpoint; credentials and scopes are fully env-driven. Integration conftest gets Zitadel-shaped mock JWT fixtures.
- **Step 6**: `LoginPage` rewritten to support both providers — Keycloak's single-step form and Zitadel-login's two-step flow (`input[name="loginName"]` → Next → password). `KEYCLOAK_URL` renamed to `IDP_URL` throughout browser e2e config, conftest, smoke tests, and service health helper. `wait_for_keycloak()` in `run.sh` replaced with provider-aware `wait_for_idp()`. `docker-compose.e2e-browser.yml` switches from `KEYCLOAK_*` to `OIDC_AUTHORITY`/`IDP_URL`.
- **Step 7**: `domain/models.py`, `useUser.ts`, `README.md`, `Makefile`, and `docs/technical/service-accounts.md` de-Keycloakified.

## Key findings

- Zitadel v4 does not support ROPC (password grant) for OIDC applications. The `real_keycloak_token` / `limited_keycloak_token` API e2e fixtures will `pytest.skip` against Zitadel. ROPC is test-only (the SPA uses PKCE); no production functionality is affected. The resolution path (e2e machine users + client_credentials) is documented as open question 9 in `tasks/0001`.
- CI and `docker-compose.e2e-browser.yml` still only run the Keycloak profile. Adding a Zitadel e2e environment and CI matrix entry (step 6 task item) is deferred to a follow-on branch.

## What's not yet done

- `docker-compose.e2e-browser.yml` Zitadel profile (step 12 in task)
- CI matrix entry for Zitadel browser e2e (step 6 in task)
- API e2e user-token acquisition for Zitadel (open question 9)