### PR TITLE
e2e: replace ROPC user-token fixtures with Playwright browser login

### DIFF
--- a/api/tests/e2e/conftest.py
+++ b/api/tests/e2e/conftest.py
@@ -5,7 +5,6 @@ from pathlib import Path
 import pytest
 import requests
 from fastapi.testclient import TestClient
-from playwright.sync_api import sync_playwright
 
 from api.main import app
 
@@ -75,6 +74,8 @@ def _get_user_token_via_browser(username: str, password: str) -> str:
     Works with both Keycloak (single-step) and Zitadel (two-step) login UIs.
     Requires Playwright with Chromium (pre-installed in the test-runner container).
     """
+    from playwright.sync_api import sync_playwright
+
     with sync_playwright() as p:
         browser = p.chromium.launch(headless=True)
         page = browser.new_page()

--- a/api/tests/e2e/conftest.py
+++ b/api/tests/e2e/conftest.py
@@ -5,11 +5,9 @@ from pathlib import Path
 import pytest
 import requests
 from fastapi.testclient import TestClient
+from playwright.sync_api import sync_playwright
 
 from api.main import app
-
-# Import the shared service readiness fixture
-# This ensures all services are ready before API E2E tests start
 
 # Add the browser E2E helpers to Python path for shared modules
 browser_e2e_path = Path(__file__).parent.parent.parent.parent / "tests" / "e2e-browser"
@@ -29,14 +27,15 @@ except ImportError:
 # are provider-agnostic (works with both Keycloak and Zitadel).
 OIDC_ISSUER_URL = os.environ.get("OIDC_ISSUER_URL", "http://keycloak-e2e:8080/realms/stuf")
 
-# Scopes for user (password grant) and service account (client_credentials) tokens.
-# Override these env vars when running against Zitadel.  Keycloak defaults use the
-# stuf:access scope; Zitadel requires project-audience and role scopes instead.
-OIDC_USER_SCOPES = os.environ.get("OIDC_USER_SCOPES", "openid stuf:access")
-OIDC_SERVICE_ACCOUNT_SCOPES = os.environ.get("OIDC_SERVICE_ACCOUNT_SCOPES", "stuf:access")
+# SPA URL for browser-based token acquisition.
+# The test-runner container has Playwright+Chromium installed and the SPA is
+# reachable on the Docker-internal network at the default below.
+SPA_URL = os.environ.get("SPA_URL", "http://spa-e2e:3000")
+SPA_HOST = SPA_URL.replace("http://", "").replace("https://", "")
 
-# SPA client ID for the password-grant user fixture.
-OIDC_SPA_CLIENT_ID = os.environ.get("OIDC_SPA_CLIENT_ID", "stuf-spa")
+# Scopes for service account (client_credentials) tokens.
+# Override this env var when running against Zitadel.
+OIDC_SERVICE_ACCOUNT_SCOPES = os.environ.get("OIDC_SERVICE_ACCOUNT_SCOPES", "stuf:access")
 
 # Service-account credentials — written to /bootstrap/generated.env by zitadel-init
 # for the Zitadel profile; defaults match the Keycloak realm-export.json fixture.
@@ -70,24 +69,84 @@ def _get_token_endpoint() -> str:
     return _token_endpoint
 
 
-@pytest.fixture
-def real_keycloak_token(ensure_services_ready):  # noqa: F811
-    """Get a real user token using the password grant."""
+def _get_user_token_via_browser(username: str, password: str) -> str:
+    """Get an access token by completing the OIDC login flow through the SPA.
 
-    data = {
-        "grant_type": "password",
-        "client_id": OIDC_SPA_CLIENT_ID,
-        "username": "testuser",
-        "password": "password",
-        "scope": OIDC_USER_SCOPES,
-    }
+    Works with both Keycloak (single-step) and Zitadel (two-step) login UIs.
+    Requires Playwright with Chromium (pre-installed in the test-runner container).
+    """
+    with sync_playwright() as p:
+        browser = p.chromium.launch(headless=True)
+        page = browser.new_page()
+        try:
+            page.goto(SPA_URL)
+            page.wait_for_timeout(2000)
 
-    response = requests.post(_get_token_endpoint(), data=data)
+            # Trigger the OIDC redirect
+            page.wait_for_selector('button:text("Sign in")', timeout=10000)
+            page.click('button:text("Sign in")')
 
-    if response.status_code != 200:
-        pytest.skip(f"Could not get user token from IDP: {response.text}")
+            # Wait for login form — combined selector handles both Keycloak and Zitadel
+            combined = 'input[name="username"], input[name="loginName"]'
+            page.wait_for_selector(combined, timeout=15000)
 
-    return response.json()["access_token"]
+            if page.locator('input[name="loginName"]').count() > 0:
+                # Zitadel two-step: login name → Next → password → Sign in
+                page.fill('input[name="loginName"]', username)
+                page.click('button[type="submit"]')
+                page.wait_for_selector('input[name="password"]', timeout=10000)
+                page.fill('input[name="password"]', password)
+                page.click('button[type="submit"]')
+            else:
+                # Keycloak single-step
+                page.fill('input[name="username"]', username)
+                page.fill('input[name="password"]', password)
+                page.click('button[type="submit"], input[type="submit"]')
+
+            # Wait for the OIDC callback redirect back to the SPA
+            page.wait_for_url(f"*{SPA_HOST}*", timeout=15000)
+            # Give oidc-client-ts time to exchange the auth code for tokens
+            page.wait_for_timeout(3000)
+
+            token_data = page.evaluate("""
+                () => {
+                    const key = Object.keys(localStorage).find(
+                        k => k.startsWith('oidc.user:')
+                    );
+                    if (!key) return null;
+                    try { return JSON.parse(localStorage.getItem(key)); }
+                    catch { return null; }
+                }
+            """)
+
+            if not token_data or "access_token" not in token_data:
+                keys = page.evaluate("() => Object.keys(localStorage)")
+                raise RuntimeError(
+                    f"No access_token in localStorage after login as {username}. "
+                    f"localStorage keys: {keys}"
+                )
+
+            return token_data["access_token"]
+        finally:
+            browser.close()
+
+
+@pytest.fixture(scope="session")
+def user_token(ensure_services_ready):  # noqa: F811
+    """Get a real user token via browser-based OIDC login."""
+    try:
+        return _get_user_token_via_browser("testuser@example.com", "password")
+    except Exception as e:
+        pytest.skip(f"Could not get user token via browser login: {e}")
+
+
+@pytest.fixture(scope="session")
+def limited_user_token(ensure_services_ready):  # noqa: F811
+    """Get a token for a user with limited permissions via browser-based OIDC login."""
+    try:
+        return _get_user_token_via_browser("limiteduser@example.com", "password")
+    except Exception as e:
+        pytest.skip(f"Could not get limited user token via browser login: {e}")
 
 
 @pytest.fixture
@@ -97,36 +156,16 @@ def e2e_client():
 
 
 @pytest.fixture
-def limited_keycloak_token(ensure_services_ready):  # noqa: F811
-    """Get a token for a user with limited permissions."""
-
-    data = {
-        "grant_type": "password",
-        "client_id": OIDC_SPA_CLIENT_ID,
-        "username": "limiteduser",
-        "password": "password",
-        "scope": OIDC_USER_SCOPES,
-    }
-
-    response = requests.post(_get_token_endpoint(), data=data)
-
-    if response.status_code != 200:
-        pytest.skip(f"Could not get limited user token from IDP: {response.text}")
-
-    return response.json()["access_token"]
-
-
-@pytest.fixture
-def e2e_authenticated_client(e2e_client, real_keycloak_token):
+def e2e_authenticated_client(e2e_client, user_token):
     """Authenticated client for E2E tests"""
-    e2e_client.headers.update({"Authorization": f"Bearer {real_keycloak_token}"})
+    e2e_client.headers.update({"Authorization": f"Bearer {user_token}"})
     return e2e_client
 
 
 @pytest.fixture
-def e2e_limited_client(e2e_client, limited_keycloak_token):
+def e2e_limited_client(e2e_client, limited_user_token):
     """Limited user client for E2E tests"""
-    e2e_client.headers.update({"Authorization": f"Bearer {limited_keycloak_token}"})
+    e2e_client.headers.update({"Authorization": f"Bearer {limited_user_token}"})
     return e2e_client
 
 

--- a/api/tests/e2e/test_auth_e2e.py
+++ b/api/tests/e2e/test_auth_e2e.py
@@ -23,11 +23,11 @@ class TestAuthenticationE2E:
         assert OIDC_ISSUER_URL is not None
         assert len(OIDC_VALID_AUDIENCES) > 0
 
-    def test_token_validation_with_real_idp(self, real_keycloak_token):
+    def test_token_validation_with_real_idp(self, user_token):
         """Test token validation against the active OIDC provider"""
 
         # This should work with a real token from the fixture
-        token_info = verify_jwt_token(real_keycloak_token)
+        token_info = verify_jwt_token(user_token)
 
         assert token_info is not None
         # JWT tokens have standard claims, not "active" like introspection

--- a/api/tests/e2e/test_service_account_e2e.py
+++ b/api/tests/e2e/test_service_account_e2e.py
@@ -114,12 +114,12 @@ class TestServiceAccountE2E:
         assert isinstance(principal.roles, list)
 
     def test_service_account_vs_user_token_difference(
-        self, service_account_token, real_keycloak_token
+        self, service_account_token, user_token
     ):
         """Test that service account and user tokens are handled differently"""
         # Get token payloads
         service_payload = verify_jwt_token(service_account_token)
-        user_payload = verify_jwt_token(real_keycloak_token)
+        user_payload = verify_jwt_token(user_token)
 
         # Service account token characteristics
         assert "azp" in service_payload or "client_id" in service_payload

--- a/tasks/0001-support-zitadel-as-oidc-provider.md
+++ b/tasks/0001-support-zitadel-as-oidc-provider.md
@@ -316,20 +316,19 @@ metadata for `collections`).
    `ServiceAccount.client_id` to drop the "from Keycloak" wording. No code
    change needed; the model is already provider-neutral.
 
-7. **`api/tests/e2e/conftest.py`** — make the password-grant and
-   client-credentials grant fixtures discovery-aware (use the issuer's
-   `token_endpoint` from discovery rather than templating
-   `/realms/{realm}/protocol/openid-connect/token`). Add an `OIDC_PROVIDER`
-   env discriminator the fixture can use to pick scopes correctly
-   (`stuf:access` for Keycloak vs the audience+roles scopes for Zitadel).
-   **Note:** Zitadel v4 does not support the Resource Owner Password
-   Credentials (ROPC / password grant) for OIDC applications — the SPA
-   app is created with `OIDC_GRANT_TYPE_AUTHORIZATION_CODE` and
-   `OIDC_GRANT_TYPE_REFRESH_TOKEN` only. The `real_keycloak_token` and
-   `limited_keycloak_token` fixtures therefore cannot obtain user tokens
-   against Zitadel and will `pytest.skip`. ROPC is test-only (the SPA
-   uses the authorization code PKCE flow); no production functionality is
-   affected. See open question 9 for the resolution path.
+7. **`api/tests/e2e/conftest.py`** — *(Implemented — PRs #90, #91)*
+   - Token endpoint resolved via OIDC discovery (`/.well-known/openid-configuration`)
+     rather than templated Keycloak realm path.
+   - ROPC removed entirely. User tokens (`user_token`, `limited_user_token`) are
+     now obtained by driving a real browser login through the SPA with Playwright
+     (headless Chromium). Provider detection (Keycloak single-step vs Zitadel
+     two-step) is handled inline; the test-runner container already has
+     Playwright + Chromium installed and the SPA is on the same Docker network,
+     so no new infrastructure was needed.
+   - Service-account tokens still use `client_credentials` via `requests`
+     (works for both providers).
+   - `OIDC_SERVICE_ACCOUNT_SCOPES` remains env-configurable for Zitadel's
+     audience+roles scopes vs Keycloak's `stuf:access`.
 
 8. **`api/tests/integration/conftest.py` +
    `api/tests/fixtures/test_data.py`** — the mocked token payloads currently

--- a/tasks/0001-support-zitadel-as-oidc-provider.md
+++ b/tasks/0001-support-zitadel-as-oidc-provider.md
@@ -485,20 +485,15 @@ These need decisions or upstream investigation before implementation:
    `zitadel-login` uses `PORT` env var to bind on 8090 instead of the
    default 3000.
 
-9. **API e2e user-token acquisition under Zitadel.** The `real_keycloak_token`
-   and `limited_keycloak_token` API e2e fixtures use the ROPC password grant,
-   which Zitadel v4 does not support for OIDC applications. Options:
-   - (a) Add e2e machine users to `instance.yaml` that mirror each test
-     human user's roles and collections, then use `client_credentials` to
-     obtain tokens for them — subject to confirming that the
-     `preAccessTokenCreation` Action fires for client_credentials flows
-     (open question 1 note).
-   - (b) Use the Zitadel session API to authenticate a human user
-     server-side and exchange the session for tokens (more complex, closer
-     to a real user flow).
-   Option (a) is lower friction; it reuses the same fixture shape and only
-   requires new `instance.yaml` entries and corresponding `generated.env`
-   writes from `provision.py`.
+9. **API e2e user-token acquisition under Zitadel.** *(Resolved — 2026-05-04)*
+   The ROPC-based `real_keycloak_token` / `limited_keycloak_token` fixtures were
+   replaced with Playwright browser-based login (`user_token` /
+   `limited_user_token`).  The test-runner container already has Playwright +
+   Chromium installed and the SPA is on the same Docker network, so no new
+   infrastructure was needed.  Provider detection (Keycloak single-step vs
+   Zitadel two-step) is handled inline in `conftest.py`, mirroring the logic
+   already in `login_page.py`.  ROPC is no longer used anywhere in the test
+   suite.
 
 ## Suggested implementation order
 


### PR DESCRIPTION
Ref: #85. Follows #90.

This one came about because Zitadel doesn't support Resource-Owner Password Credential (ROPC), with good reason, whereas CI was unnecessarily depending on it for the STUF e2e tests with Keycloak. So we needed to fix this before continuing with the Zitadel support.

## Summary

- Removes ROPC (password grant) from the API e2e test suite entirely — the only remaining use of `grant_type=password` in the repo.
- `real_keycloak_token` / `limited_keycloak_token` fixtures replaced by `user_token` / `limited_user_token`, which drive a real browser login through the SPA using Playwright. Provider detection (Keycloak single-step vs Zitadel two-step) is handled inline, mirroring `login_page.py`.
- Fixtures are session-scoped: one browser launch, two logins (testuser + limiteduser), tokens cached for the full test run.
- No new infrastructure required — the test-runner container already has Playwright + Chromium installed and the SPA is reachable at `http://spa-e2e:3000` on the Docker-internal network.
- `OIDC_USER_SCOPES` and `OIDC_SPA_CLIENT_ID` constants removed from conftest (were only needed to build the ROPC request body).
- Open question 9 in `tasks/0001` marked resolved.