### PR TITLE
api+spa: Zitadel-compatible credentials, JWT coverage, configurable OIDC

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,10 @@ tests/e2e-browser/reports/
 tests/e2e-browser/auth-storage-state.json
 tests/.venv/
 
+# Zitadel e2e bootstrap (generated at runtime; keep directory, ignore contents)
+tests/e2e-browser/.zitadel-bootstrap/*
+!tests/e2e-browser/.zitadel-bootstrap/.gitkeep
+
 # SPA build artifacts
 spa/build/
 spa/dist/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 STUF (Secure Trusted Upload Facility) is a secure file upload system consisting of:
 - **FastAPI backend** (`api/`) for authentication and file management
 - **React SPA** (`spa/`) for user interface
-- **Docker Compose** setup with Keycloak authentication and MinIO object storage
+- **Docker Compose** setup with OIDC authentication (Keycloak or Zitadel) and MinIO object storage
 - **Comprehensive documentation** using MkDocs
 
 ## Development Commands
@@ -27,15 +27,18 @@ make test-cov          # Tests with coverage report
 
 ### Docker Environment
 ```bash
-# Start full development environment
-docker-compose up -d
+# Start full development environment (Keycloak profile, default)
+docker compose --profile keycloak up -d
 
-# Start E2E test environment
-docker-compose -f docker-compose.e2e.yml up -d
+# Start with Zitadel instead
+docker compose --profile zitadel up -d
+
+# Start E2E test environment (Keycloak)
+docker compose -f docker-compose.e2e.yml --profile keycloak up -d
 
 # Stop and clean up
-docker-compose down
-docker-compose down -v  # Remove volumes/data
+docker compose down
+docker compose down -v  # Remove volumes/data
 ```
 
 ### Documentation
@@ -56,7 +59,7 @@ npm run build # Production build
 
 ### API Layer (`api/`)
 - **FastAPI application** with modular router organization
-- **Keycloak integration** for OAuth2/OIDC authentication using JWT signature verification
+- **Provider-agnostic OIDC authentication** via OIDC discovery and JWT signature verification (supports both Keycloak and Zitadel)
 - **Dual authentication support** for both user accounts and service accounts
 - **Attribute-based authorization** with collection-level permissions stored in JWT collections claim
 - **MinIO integration** for S3-compatible object storage
@@ -72,7 +75,8 @@ npm run build # Production build
 
 ### Environment Configuration
 All services configured via environment variables with development defaults:
-- Keycloak realm/client configuration
+- OIDC configuration: `OIDC_ISSUER_URL`, `OIDC_BASE_URL`, `OIDC_VALID_AUDIENCES`, `OIDC_SPA_CLIENT_ID`
+- SPA OIDC: `OIDC_AUTHORITY`, `OIDC_CLIENT_ID` (or legacy `KEYCLOAK_URL`/`KEYCLOAK_REALM` for backwards compatibility)
 - MinIO credentials and endpoints
 - API/SPA port configuration
 
@@ -87,8 +91,8 @@ All services configured via environment variables with development defaults:
 ### Authentication Flow
 
 #### User Authentication
-1. React SPA uses `react-oidc-context` for Keycloak OIDC flow
-2. FastAPI backend validates tokens via JWT signature verification against Keycloak public keys
+1. React SPA uses `react-oidc-context` for OIDC flow (provider-agnostic; configured via `OIDC_AUTHORITY`)
+2. FastAPI backend validates tokens via JWT signature verification using OIDC discovery (`OIDC_ISSUER_URL`)
 3. Users must have appropriate collection permissions in their JWT collections claim or admin role
 
 #### Service Account Authentication
@@ -111,7 +115,7 @@ All services configured via environment variables with development defaults:
 
 ### API Requirements
 - FastAPI >=0.104.0 with Uvicorn
-- Keycloak integration via python-jose and requests
+- OIDC integration via python-jose (JWT) and requests (discovery/JWKS)
 - MinIO client for S3-compatible storage
 - Pydantic 2.3.0 for data validation
 
@@ -123,31 +127,33 @@ All services configured via environment variables with development defaults:
 ## Development Workflow
 
 ### Authentication Setup
-1. Keycloak auto-configures with realm `stuf` and test users
-2. Default admin user: `admin@example.com` / `password`
+1. Keycloak auto-configures with realm `stuf` and test users; Zitadel is provisioned by `docker/zitadel-init/`
+2. Default admin user: `admin@example.com` / `Password1!` (both Keycloak and Zitadel)
 3. Collection permissions stored in JWT collections claim as JSON: `{"collection-name": ["read", "write", "delete"]}`
-4. Service accounts created as Keycloak clients with service account roles enabled
+4. Service accounts: Keycloak clients with service-account roles enabled; Zitadel machine users with JWT access tokens
 5. Both users and service accounts use same collection permission format
 
 ### File Upload Flow
-1. User authenticates via Keycloak OIDC
+1. User authenticates via OIDC (Keycloak or Zitadel)
 2. Frontend uploads files with metadata to API
 3. API validates permissions and stores in MinIO with user-specific paths
 4. Metadata and audit information stored with files
 
 ### Testing Authentication
 - Use `@pytest.fixture` for auth tokens in tests
-- Mock Keycloak responses for unit tests
-- E2E tests use real Keycloak instance
+- Integration tests mock JWT verification with both Keycloak-shaped and Zitadel-shaped payloads
+- E2E tests use a real IDP (Keycloak or Zitadel); user tokens obtained via Playwright browser login
 - Test both user and service account authentication flows
-- Service account tokens can be generated using client credentials flow
+- Service account tokens obtained via client credentials grant (`requests.post` to token endpoint)
 
 ## Service Endpoints
 
 ### Development URLs
 - SPA: http://localhost:3000
 - API: http://localhost:8000
-- Keycloak Admin: http://localhost:8080/admin (admin/admin)
+- Keycloak Admin: http://localhost:8080/admin (admin/admin) — when using `--profile keycloak`
+- Zitadel Admin: http://localhost:8080/ui/console (admin@example.com / Password1!) — when using `--profile zitadel`
+- Zitadel Login UI: http://localhost:8090 — when using `--profile zitadel`
 - MinIO Console: http://localhost:9001 (minioadmin/minioadmin)
 
 ### API Endpoints

--- a/api/auth/middleware.py
+++ b/api/auth/middleware.py
@@ -42,6 +42,22 @@ _discovery_doc: dict = {}
 _jwks_cache: dict = {"keys": [], "fetched_at": 0.0}
 _JWKS_TTL = 300  # seconds
 
+# Static collection permissions for machine users, keyed by client_id.
+# Written to generated.env by zitadel-init because Zitadel v4 cannot inject
+# custom claims into client_credentials (machine user) tokens via actions.
+# The value is base64-encoded JSON to avoid shell quoting issues in .env files.
+_MACHINE_USER_COLLECTIONS: dict = {}
+_raw_collections = os.environ.get("STUF_MACHINE_USER_COLLECTIONS", "")
+if _raw_collections:
+    import base64 as _base64
+
+    try:
+        _MACHINE_USER_COLLECTIONS = json.loads(_base64.b64decode(_raw_collections).decode())
+    except Exception:
+        logging.getLogger(__name__).warning(
+            "Failed to parse STUF_MACHINE_USER_COLLECTIONS; machine user collections will be empty"
+        )
+
 
 def _extract_roles(token_payload: dict) -> list:
     """Extract role list from a token, handling both Keycloak and Zitadel shapes.
@@ -58,6 +74,31 @@ def _extract_roles(token_payload: dict) -> list:
     if isinstance(zitadel_roles, dict):
         return list(zitadel_roles.keys())
     return []
+
+
+def _extract_collections_from_roles(roles: list) -> dict:
+    """Extract collection permissions from Zitadel col-{collection}-{perm} role names.
+
+    Zitadel v4 cannot inject custom claims into client_credentials (machine user)
+    tokens via actions, so collection permissions for machine users are encoded in
+    project role names following the convention col-{collection}-{perm}.  This
+    function decodes those roles back into the standard collections dict.
+
+    Only roles matching exactly three hyphen-delimited parts where the third part
+    is a known permission are decoded; all other roles are ignored.
+    """
+    collections: dict = {}
+    known_perms = {"read", "write", "delete"}
+    for role in roles:
+        if not role.startswith("col-"):
+            continue
+        parts = role.split("-", 2)
+        if len(parts) == 3 and parts[2] in known_perms:
+            collection, perm = parts[1], parts[2]
+            collections.setdefault(collection, [])
+            if perm not in collections[collection]:
+                collections[collection].append(perm)
+    return collections
 
 
 def _fetch_discovery() -> dict:
@@ -216,6 +257,7 @@ async def get_current_user(
         f"Successfully authenticated user: {username} with roles: {roles}, collections: {collections}"
     )
 
+
     # Ensure this is a user token, not a service account
     if not token_payload.get("preferred_username") and not token_payload.get(
         "username"
@@ -290,6 +332,19 @@ async def get_current_service_account(
         except (json.JSONDecodeError, TypeError) as e:
             logger.warning(f"Failed to parse collections claim: {e}")
 
+    # Zitadel v4 cannot inject custom claims into client_credentials tokens via
+    # actions.  Try two fallbacks:
+    # 1. Decode collection permissions from project role names (col-{col}-{perm}).
+    # 2. Read from the static STUF_MACHINE_USER_COLLECTIONS env var written by
+    #    zitadel-init (keyed by client_id).
+    if not collections:
+        collections = _extract_collections_from_roles(roles)
+        if collections:
+            logger.debug(f"Collections extracted from roles: {collections}")
+    if not collections and client_id in _MACHINE_USER_COLLECTIONS:
+        collections = _MACHINE_USER_COLLECTIONS[client_id]
+        logger.debug(f"Collections loaded from STUF_MACHINE_USER_COLLECTIONS for {client_id}")
+
     # Extract scopes
     scopes = (
         token_payload.get("scope", "").split() if token_payload.get("scope") else []
@@ -337,45 +392,24 @@ async def get_current_principal(
         logger.error("JWT verification failed - token_payload is None")
         raise credentials_exception
 
-    # Determine token type using provider-agnostic field-based detection
-    # Based on analysis of real Keycloak tokens
-
-    # Check for user-specific fields that service accounts typically don't have
+    # Discriminate user vs service-account using identity claims.
+    # Human user tokens (both Keycloak and Zitadel) carry email / given_name /
+    # family_name in the access token; machine-user tokens do not.  This is
+    # simpler and more reliable than inspecting scope or azp, which differ across
+    # providers and can include "openid" even for machine users in Zitadel.
     has_user_fields = bool(
         token_payload.get("email")
         or token_payload.get("given_name")
         or token_payload.get("family_name")
-        or token_payload.get("sid")  # Session ID - user sessions only
+        or token_payload.get("sid")  # session ID — human sessions only
     )
 
-    # Check for service account indicators
-    # Service accounts often have broader scopes or specific audience patterns
-    azp = token_payload.get("azp", "")
-    scope = token_payload.get("scope", "")
-
-    # Service accounts typically don't have openid/profile scopes and have specific azp
-    has_service_indicators = (
-        azp != OIDC_SPA_CLIENT_ID  # Users use the SPA OIDC client
-        and "openid" not in scope  # Service accounts usually don't have openid scope
-        and "profile" not in scope  # Service accounts usually don't have profile scope
-        and "email" not in scope  # Service accounts usually don't have email scope
-    )
-
-    if has_user_fields and not has_service_indicators:
-        # Token has user-specific fields → User token
-        logger.debug(f"Detected user token (has user-specific fields)")
+    if has_user_fields:
+        logger.debug("Detected user token (has user identity fields)")
         return await get_current_user(token)
-    elif has_service_indicators and not has_user_fields:
-        # Token has service indicators and no user fields → Service account token
-        logger.debug(
-            f"Detected service account token (service indicators, no user fields)"
-        )
-        return await get_current_service_account(token)
     else:
-        logger.error(
-            f"Cannot determine token type - has_user_fields: {bool(has_user_fields)}, has_service_indicators: {bool(has_service_indicators)}"
-        )
-        raise credentials_exception
+        logger.debug("Detected service account token (no user identity fields)")
+        return await get_current_service_account(token)
 
 
 def require_role(required_role: str):

--- a/api/auth/middleware.py
+++ b/api/auth/middleware.py
@@ -42,23 +42,6 @@ _discovery_doc: dict = {}
 _jwks_cache: dict = {"keys": [], "fetched_at": 0.0}
 _JWKS_TTL = 300  # seconds
 
-# Static collection permissions for machine users, keyed by client_id.
-# Written to generated.env by zitadel-init because Zitadel v4 cannot inject
-# custom claims into client_credentials (machine user) tokens via actions.
-# The value is base64-encoded JSON to avoid shell quoting issues in .env files.
-_MACHINE_USER_COLLECTIONS: dict = {}
-_raw_collections = os.environ.get("STUF_MACHINE_USER_COLLECTIONS", "")
-if _raw_collections:
-    import base64 as _base64
-
-    try:
-        _MACHINE_USER_COLLECTIONS = json.loads(_base64.b64decode(_raw_collections).decode())
-    except Exception:
-        logging.getLogger(__name__).warning(
-            "Failed to parse STUF_MACHINE_USER_COLLECTIONS; machine user collections will be empty"
-        )
-
-
 def _extract_roles(token_payload: dict) -> list:
     """Extract role list from a token, handling both Keycloak and Zitadel shapes.
 
@@ -74,31 +57,6 @@ def _extract_roles(token_payload: dict) -> list:
     if isinstance(zitadel_roles, dict):
         return list(zitadel_roles.keys())
     return []
-
-
-def _extract_collections_from_roles(roles: list) -> dict:
-    """Extract collection permissions from Zitadel col-{collection}-{perm} role names.
-
-    Zitadel v4 cannot inject custom claims into client_credentials (machine user)
-    tokens via actions, so collection permissions for machine users are encoded in
-    project role names following the convention col-{collection}-{perm}.  This
-    function decodes those roles back into the standard collections dict.
-
-    Only roles matching exactly three hyphen-delimited parts where the third part
-    is a known permission are decoded; all other roles are ignored.
-    """
-    collections: dict = {}
-    known_perms = {"read", "write", "delete"}
-    for role in roles:
-        if not role.startswith("col-"):
-            continue
-        parts = role.split("-", 2)
-        if len(parts) == 3 and parts[2] in known_perms:
-            collection, perm = parts[1], parts[2]
-            collections.setdefault(collection, [])
-            if perm not in collections[collection]:
-                collections[collection].append(perm)
-    return collections
 
 
 def _fetch_discovery() -> dict:
@@ -331,20 +289,6 @@ async def get_current_service_account(
             logger.debug(f"Parsed collections: {collections}")
         except (json.JSONDecodeError, TypeError) as e:
             logger.warning(f"Failed to parse collections claim: {e}")
-
-    # Zitadel v4 cannot inject custom claims into client_credentials tokens via
-    # actions (see https://github.com/pyx-industries/stuf/issues/96).  Try two
-    # fallbacks:
-    # 1. Decode collection permissions from project role names (col-{col}-{perm}).
-    # 2. Read from the static STUF_MACHINE_USER_COLLECTIONS env var written by
-    #    zitadel-init (keyed by client_id).
-    if not collections:
-        collections = _extract_collections_from_roles(roles)
-        if collections:
-            logger.debug(f"Collections extracted from roles: {collections}")
-    if not collections and client_id in _MACHINE_USER_COLLECTIONS:
-        collections = _MACHINE_USER_COLLECTIONS[client_id]
-        logger.debug(f"Collections loaded from STUF_MACHINE_USER_COLLECTIONS for {client_id}")
 
     # Extract scopes
     scopes = (

--- a/api/auth/middleware.py
+++ b/api/auth/middleware.py
@@ -333,7 +333,8 @@ async def get_current_service_account(
             logger.warning(f"Failed to parse collections claim: {e}")
 
     # Zitadel v4 cannot inject custom claims into client_credentials tokens via
-    # actions.  Try two fallbacks:
+    # actions (see https://github.com/pyx-industries/stuf/issues/96).  Try two
+    # fallbacks:
     # 1. Decode collection permissions from project role names (col-{col}-{perm}).
     # 2. Read from the static STUF_MACHINE_USER_COLLECTIONS env var written by
     #    zitadel-init (keyed by client_id).

--- a/api/tests/e2e/conftest.py
+++ b/api/tests/e2e/conftest.py
@@ -50,6 +50,11 @@ OIDC_SERVICE_ACCOUNT_CLIENT_SECRET = os.environ.get(
 _token_endpoint: str | None = None
 
 
+def _is_zitadel() -> bool:
+    """Return True when the active IDP is Zitadel rather than Keycloak."""
+    return "/realms/" not in OIDC_ISSUER_URL
+
+
 def _get_token_endpoint() -> str:
     """Fetch the token endpoint from OIDC discovery (cached)."""
     global _token_endpoint

--- a/api/tests/e2e/conftest.py
+++ b/api/tests/e2e/conftest.py
@@ -136,7 +136,7 @@ def _get_user_token_via_browser(username: str, password: str) -> str:
 def user_token(ensure_services_ready):  # noqa: F811
     """Get a real user token via browser-based OIDC login."""
     try:
-        return _get_user_token_via_browser("testuser@example.com", "password")
+        return _get_user_token_via_browser("testuser@example.com", "Password1!")
     except Exception as e:
         pytest.skip(f"Could not get user token via browser login: {e}")
 
@@ -145,7 +145,7 @@ def user_token(ensure_services_ready):  # noqa: F811
 def limited_user_token(ensure_services_ready):  # noqa: F811
     """Get a token for a user with limited permissions via browser-based OIDC login."""
     try:
-        return _get_user_token_via_browser("limiteduser@example.com", "password")
+        return _get_user_token_via_browser("limiteduser@example.com", "Password1!")
     except Exception as e:
         pytest.skip(f"Could not get limited user token via browser login: {e}")
 

--- a/api/tests/e2e/test_service_account_e2e.py
+++ b/api/tests/e2e/test_service_account_e2e.py
@@ -33,7 +33,11 @@ class TestServiceAccountE2E:
         # Service accounts are identified by azp/sub, not by preferred_username prefix
         assert "iss" in token_info  # Issuer
         assert "exp" in token_info  # Expiration
-        assert "collections" in token_info  # Collection permissions
+        # NOTE: Keycloak injects 'collections' as a JWT claim; Zitadel v4 cannot
+        # inject custom claims into client_credentials tokens via actions, so the
+        # claim may be absent.  Collection permissions are verified at the API
+        # level in test_service_account_me_endpoint and test_service_account_file_*.
+        # assert "collections" in token_info
 
     def test_service_account_me_endpoint(self, e2e_service_account_client):
         """Test /api/me endpoint returns correct service account format"""
@@ -132,16 +136,20 @@ class TestServiceAccountE2E:
         for payload in [service_payload, user_payload]:
             assert "iss" in payload
             assert "exp" in payload
-            assert "collections" in payload
+        # User tokens carry the collections claim (Keycloak mapper / Zitadel action).
+        # Service account tokens may not (Zitadel v4 cannot inject claims into
+        # client_credentials tokens); collection access is role-encoded instead.
+        assert "collections" in user_payload
 
     def test_service_account_scopes_included(self, service_account_token):
-        """Test that service account tokens include OAuth2 scopes"""
+        """Test that service account tokens are valid (scope presence is provider-dependent)"""
         token_info = verify_jwt_token(service_account_token)
 
-        # Service account tokens should include scopes
-        assert "scope" in token_info
-        scopes = token_info["scope"].split() if token_info.get("scope") else []
-        assert len(scopes) > 0  # Should have at least some scopes
+        assert token_info is not None
+        # Keycloak includes a 'scope' claim in the JWT; Zitadel does not.
+        # Verify the token is valid and properly parsed instead.
+        assert "iss" in token_info
+        assert "exp" in token_info
 
     def test_service_account_authentication_flow_e2e(self, ensure_services_ready):
         """Test complete service account authentication flow from token request to API access"""

--- a/api/tests/e2e/test_service_account_e2e.py
+++ b/api/tests/e2e/test_service_account_e2e.py
@@ -34,10 +34,7 @@ class TestServiceAccountE2E:
         # Service accounts are identified by azp/sub, not by preferred_username prefix
         assert "iss" in token_info  # Issuer
         assert "exp" in token_info  # Expiration
-        # Keycloak injects 'collections' as a JWT claim; Zitadel v4 cannot inject
-        # custom claims into client_credentials tokens via actions (see issue #96).
-        if not _is_zitadel():
-            assert "collections" in token_info
+        assert "collections" in token_info
 
     def test_service_account_me_endpoint(self, e2e_service_account_client):
         """Test /api/me endpoint returns correct service account format"""

--- a/api/tests/e2e/test_service_account_e2e.py
+++ b/api/tests/e2e/test_service_account_e2e.py
@@ -15,6 +15,7 @@ from api.tests.e2e.conftest import (
     OIDC_SERVICE_ACCOUNT_CLIENT_SECRET,
     OIDC_SERVICE_ACCOUNT_SCOPES,
     _get_token_endpoint,
+    _is_zitadel,
 )
 
 
@@ -33,11 +34,10 @@ class TestServiceAccountE2E:
         # Service accounts are identified by azp/sub, not by preferred_username prefix
         assert "iss" in token_info  # Issuer
         assert "exp" in token_info  # Expiration
-        # NOTE: Keycloak injects 'collections' as a JWT claim; Zitadel v4 cannot
-        # inject custom claims into client_credentials tokens via actions, so the
-        # claim may be absent.  Collection permissions are verified at the API
-        # level in test_service_account_me_endpoint and test_service_account_file_*.
-        # assert "collections" in token_info
+        # Keycloak injects 'collections' as a JWT claim; Zitadel v4 cannot inject
+        # custom claims into client_credentials tokens via actions (see issue #96).
+        if not _is_zitadel():
+            assert "collections" in token_info
 
     def test_service_account_me_endpoint(self, e2e_service_account_client):
         """Test /api/me endpoint returns correct service account format"""
@@ -136,18 +136,21 @@ class TestServiceAccountE2E:
         for payload in [service_payload, user_payload]:
             assert "iss" in payload
             assert "exp" in payload
-        # User tokens carry the collections claim (Keycloak mapper / Zitadel action).
-        # Service account tokens may not (Zitadel v4 cannot inject claims into
-        # client_credentials tokens); collection access is role-encoded instead.
+        # Both token types carry the collections claim on Keycloak; Zitadel v4
+        # cannot inject custom claims into client_credentials tokens (see issue #96).
+        if not _is_zitadel():
+            assert "collections" in service_payload
         assert "collections" in user_payload
 
     def test_service_account_scopes_included(self, service_account_token):
-        """Test that service account tokens are valid (scope presence is provider-dependent)"""
+        """Test that service account tokens include expected scopes"""
         token_info = verify_jwt_token(service_account_token)
 
         assert token_info is not None
-        # Keycloak includes a 'scope' claim in the JWT; Zitadel does not.
-        # Verify the token is valid and properly parsed instead.
+        # Keycloak includes a 'scope' claim in the JWT; Zitadel does not (see issue #96).
+        if not _is_zitadel():
+            assert "scope" in token_info
+            assert "stuf:access" in token_info.get("scope", "").split()
         assert "iss" in token_info
         assert "exp" in token_info
 

--- a/api/tests/integration/conftest.py
+++ b/api/tests/integration/conftest.py
@@ -269,6 +269,24 @@ def mock_jwt_verification():
                 "exp": int(time.time()) + 3600,
                 "iat": int(time.time()),
             }
+        elif token == "zitadel-limited-user-integration-test-token":
+            return {
+                "sub": "limiteduser-zitadel-id",
+                "preferred_username": "limiteduser@example.com",
+                "email": "limiteduser@example.com",
+                "given_name": "Limited",
+                "family_name": "User",
+                "azp": "abc123-spa-client-id",
+                "scope": "openid profile email urn:zitadel:iam:org:project:roles urn:zitadel:iam:org:project:id:12345:aud",
+                "urn:zitadel:iam:org:project:roles": {
+                    "project-participant": {"orgId": "orgDomain"},
+                },
+                "collections": {"other": ["read", "write", "delete"]},
+                "aud": ["abc123-spa-client-id", "12345"],
+                "iss": "http://localhost:8080",
+                "exp": int(time.time()) + 3600,
+                "iat": int(time.time()),
+            }
         return None
 
     with patch("auth.middleware.verify_jwt_token", side_effect=mock_verify_jwt_token):
@@ -321,3 +339,9 @@ def zitadel_admin_headers():
 def zitadel_service_account_headers():
     """Headers with Zitadel-shaped service account token (project roles claim)"""
     return {"Authorization": "Bearer zitadel-service-account-integration-test-token"}
+
+
+@pytest.fixture
+def zitadel_limited_user_headers():
+    """Headers with Zitadel-shaped limited user token (no access to test collection)"""
+    return {"Authorization": "Bearer zitadel-limited-user-integration-test-token"}

--- a/api/tests/integration/test_files_api.py
+++ b/api/tests/integration/test_files_api.py
@@ -8,15 +8,20 @@ from api.tests.fixtures.test_data import SAMPLE_FILES
 logger = logging.getLogger(__name__)
 
 
-# Parameterize authentication types for comprehensive testing
+# Parameterize authentication types for comprehensive testing.
+# Each list covers both Keycloak-shaped and Zitadel-shaped tokens so the
+# integration suite exercises both token formats through the middleware.
 AUTH_FIXTURES = [
-    "authenticated_headers",  # User authentication
-    "service_account_headers",  # Service account authentication
+    "authenticated_headers",  # Keycloak user
+    "service_account_headers",  # Keycloak service account
+    "zitadel_authenticated_headers",  # Zitadel user
+    "zitadel_service_account_headers",  # Zitadel service account
 ]
 
 LIMITED_AUTH_FIXTURES = [
-    "limited_user_headers",  # Limited user authentication
-    "limited_service_account_headers",  # Limited service account authentication
+    "limited_user_headers",  # Keycloak limited user
+    "limited_service_account_headers",  # Keycloak limited service account
+    "zitadel_limited_user_headers",  # Zitadel limited user
 ]
 
 

--- a/docker/keycloak/data/import/realm-export.json
+++ b/docker/keycloak/data/import/realm-export.json
@@ -3,7 +3,9 @@
   "enabled": true,
   "sslRequired": "none",
   "registrationAllowed": false,
-  "requiredCredentials": ["password"],
+  "requiredCredentials": [
+    "password"
+  ],
   "roles": {
     "realm": [
       {
@@ -106,7 +108,8 @@
             "claim.name": "collections",
             "jsonType.label": "JSON",
             "access.token.claim": "true",
-            "id.token.claim": "true"
+            "id.token.claim": "true",
+            "userinfo.token.claim": "true"
           }
         },
         {
@@ -179,7 +182,11 @@
         "token.endpoint.auth.signing.alg": "RS256",
         "introspection.response.audience.enabled": "true"
       },
-      "defaultClientScopes": ["web-origins", "roles", "stuf:access"]
+      "defaultClientScopes": [
+        "web-origins",
+        "roles",
+        "stuf:access"
+      ]
     },
     {
       "clientId": "stuf-api",
@@ -212,11 +219,13 @@
       "credentials": [
         {
           "type": "password",
-          "value": "password",
+          "value": "Password1!",
           "temporary": false
         }
       ],
-      "realmRoles": ["admin"],
+      "realmRoles": [
+        "admin"
+      ],
       "attributes": {
         "collections": [
           "{\"test\":[\"read\",\"write\",\"delete\"],\"restricted\":[\"read\",\"write\",\"delete\"],\"shared\":[\"read\",\"write\",\"delete\"]}"
@@ -232,11 +241,13 @@
       "credentials": [
         {
           "type": "password",
-          "value": "password",
+          "value": "Password1!",
           "temporary": false
         }
       ],
-      "realmRoles": ["project-participant"],
+      "realmRoles": [
+        "project-participant"
+      ],
       "attributes": {
         "collections": [
           "{\"test\":[\"read\",\"write\",\"delete\"],\"collection-1-docs\":[\"read\",\"write\"],\"collection-2-contracts\":[\"read\"],\"collection-3-cat-pics\":[\"read\",\"write\",\"delete\"]}"
@@ -252,11 +263,13 @@
       "credentials": [
         {
           "type": "password",
-          "value": "test-password",
+          "value": "Password1!",
           "temporary": false
         }
       ],
-      "realmRoles": ["admin"],
+      "realmRoles": [
+        "admin"
+      ],
       "attributes": {
         "collections": [
           "{\"test\":[\"read\",\"write\",\"delete\"],\"restricted\":[\"read\",\"write\",\"delete\"],\"shared\":[\"read\",\"write\",\"delete\"]}"
@@ -272,11 +285,13 @@
       "credentials": [
         {
           "type": "password",
-          "value": "test-password",
+          "value": "Password1!",
           "temporary": false
         }
       ],
-      "realmRoles": ["trust-architect"],
+      "realmRoles": [
+        "trust-architect"
+      ],
       "attributes": {
         "collections": [
           "{\"test\":[\"read\",\"write\",\"delete\"],\"restricted\":[\"read\",\"write\",\"delete\"],\"shared\":[\"read\",\"write\",\"delete\"]}"
@@ -292,11 +307,13 @@
       "credentials": [
         {
           "type": "password",
-          "value": "test-password",
+          "value": "Password1!",
           "temporary": false
         }
       ],
-      "realmRoles": ["project-participant"],
+      "realmRoles": [
+        "project-participant"
+      ],
       "attributes": {
         "collections": [
           "{\"test\":[\"read\",\"write\"],\"restricted\":[\"read\",\"write\"],\"shared\":[\"read\",\"write\"]}"
@@ -312,13 +329,17 @@
       "credentials": [
         {
           "type": "password",
-          "value": "test-password",
+          "value": "Password1!",
           "temporary": false
         }
       ],
-      "realmRoles": ["project-participant"],
+      "realmRoles": [
+        "project-participant"
+      ],
       "attributes": {
-        "collections": ["{\"test\":[\"read\",\"write\"]}"]
+        "collections": [
+          "{\"test\":[\"read\",\"write\"]}"
+        ]
       }
     },
     {
@@ -330,13 +351,17 @@
       "credentials": [
         {
           "type": "password",
-          "value": "test-password",
+          "value": "Password1!",
           "temporary": false
         }
       ],
-      "realmRoles": ["project-participant"],
+      "realmRoles": [
+        "project-participant"
+      ],
       "attributes": {
-        "collections": ["{\"shared\":[\"read\",\"write\"]}"]
+        "collections": [
+          "{\"shared\":[\"read\",\"write\"]}"
+        ]
       }
     },
     {
@@ -348,13 +373,17 @@
       "credentials": [
         {
           "type": "password",
-          "value": "test-password",
+          "value": "Password1!",
           "temporary": false
         }
       ],
-      "realmRoles": ["project-participant"],
+      "realmRoles": [
+        "project-participant"
+      ],
       "attributes": {
-        "collections": ["{\"test\":[\"read\",\"write\"]}"]
+        "collections": [
+          "{\"test\":[\"read\",\"write\"]}"
+        ]
       }
     },
     {
@@ -364,9 +393,13 @@
       "firstName": "",
       "lastName": "",
       "email": "",
-      "realmRoles": ["service"],
+      "realmRoles": [
+        "service"
+      ],
       "attributes": {
-        "collections": ["{\"test\":[\"read\"],\"shared\":[\"read\"]}"]
+        "collections": [
+          "{\"test\":[\"read\"],\"shared\":[\"read\"]}"
+        ]
       }
     }
   ]

--- a/docker/zitadel-init/dev/instance.yaml
+++ b/docker/zitadel-init/dev/instance.yaml
@@ -42,7 +42,7 @@ human_users:
     firstName: Test
     lastName: User
     email: testuser@example.com
-    password: password
+    password: Password1!
     roles: [project-participant]
     collections:
       test: [read, write, delete]
@@ -54,7 +54,7 @@ human_users:
     firstName: Test
     lastName: Admin
     email: admin@test.example.com
-    password: test-password
+    password: Password1!
     roles: [admin]
     collections:
       test: [read, write, delete]
@@ -65,7 +65,7 @@ human_users:
     firstName: Test
     lastName: Architect
     email: ta@test.example.com
-    password: test-password
+    password: Password1!
     roles: [trust-architect]
     collections:
       test: [read, write, delete]
@@ -76,7 +76,7 @@ human_users:
     firstName: Test
     lastName: FullUser
     email: full@test.example.com
-    password: test-password
+    password: Password1!
     roles: [project-participant]
     collections:
       test: [read, write]
@@ -87,7 +87,7 @@ human_users:
     firstName: Test
     lastName: LimitedUser
     email: limited@test.example.com
-    password: test-password
+    password: Password1!
     roles: [project-participant]
     collections:
       test: [read, write]
@@ -96,7 +96,7 @@ human_users:
     firstName: Test
     lastName: SharedUser
     email: shared@test.example.com
-    password: test-password
+    password: Password1!
     roles: [project-participant]
     collections:
       shared: [read, write]
@@ -105,7 +105,7 @@ human_users:
     firstName: Test
     lastName: InactiveUser
     email: inactive@test.example.com
-    password: test-password
+    password: Password1!
     roles: [project-participant]
     collections:
       test: [read, write]

--- a/docker/zitadel-init/provision.py
+++ b/docker/zitadel-init/provision.py
@@ -33,14 +33,16 @@ FIXTURE_PATH = os.environ.get("FIXTURE_PATH", "/fixtures/dev/instance.yaml")
 # - preferred_username: not in Zitadel JWT access tokens by default; mirrors
 #   the Keycloak claim the STUF API middleware reads.
 # - collections: user metadata stored as a JSON object; getMetadata() returns
-#   entries with value already JSON-decoded (no atob/JSON.parse needed).
+#   a wrapper {metadata: [...]} where each entry's value is already decoded
+#   from base64+JSON (no atob/JSON.parse needed).
 COLLECTIONS_ACTION_SCRIPT = """\
 function preAccessTokenCreation(ctx, api) {
   if (ctx.v1.user.preferredLoginName) {
     api.v1.claims.setClaim("preferred_username", ctx.v1.user.preferredLoginName);
   }
-  var md = ctx.v1.user.getMetadata();
-  if (!md) { return; }
+  var result = ctx.v1.user.getMetadata();
+  if (!result || !result.metadata) { return; }
+  var md = result.metadata;
   for (var i = 0; i < md.length; i++) {
     if (md[i].key === "collections") {
       api.v1.claims.setClaim("collections", md[i].value);

--- a/docker/zitadel-init/provision.py
+++ b/docker/zitadel-init/provision.py
@@ -36,7 +36,9 @@ FIXTURE_PATH = os.environ.get("FIXTURE_PATH", "/fixtures/dev/instance.yaml")
 #   entries with value already JSON-decoded (no atob/JSON.parse needed).
 COLLECTIONS_ACTION_SCRIPT = """\
 function preAccessTokenCreation(ctx, api) {
-  api.v1.claims.setClaim("preferred_username", ctx.v1.user.preferredLoginName);
+  if (ctx.v1.user.preferredLoginName) {
+    api.v1.claims.setClaim("preferred_username", ctx.v1.user.preferredLoginName);
+  }
   var md = ctx.v1.user.getMetadata();
   if (!md) { return; }
   for (var i = 0; i < md.length; i++) {

--- a/docker/zitadel-init/provision.py
+++ b/docker/zitadel-init/provision.py
@@ -27,22 +27,21 @@ MACHINE_KEY_PATH = os.environ.get("MACHINE_KEY_PATH", "/bootstrap/zitadel-admin-
 BOOTSTRAP_DIR = os.environ.get("BOOTSTRAP_DIR", "/bootstrap")
 FIXTURE_PATH = os.environ.get("FIXTURE_PATH", "/fixtures/dev/instance.yaml")
 
-# Injected into every access token via the preAccessTokenCreation trigger.
+# Fired on the PRE_ACCESS_TOKEN_CREATION trigger (flow 2, trigger type 5).
+# Fires for both authorization-code (human) and client_credentials (machine)
+# grants when the project's access-token type is JWT.
 # - preferred_username: not in Zitadel JWT access tokens by default; mirrors
 #   the Keycloak claim the STUF API middleware reads.
-# - collections: user metadata injected as a JSON object claim; mirrors the
-#   Keycloak stuf:access scope's collections attribute mapper.
-# Metadata values arrive as base64-encoded strings in ctx.v1.user.metadataList.
+# - collections: user metadata stored as a JSON object; getMetadata() returns
+#   entries with value already JSON-decoded (no atob/JSON.parse needed).
 COLLECTIONS_ACTION_SCRIPT = """\
 function preAccessTokenCreation(ctx, api) {
   api.v1.claims.setClaim("preferred_username", ctx.v1.user.preferredLoginName);
-  var md = ctx.v1.user.metadataList;
+  var md = ctx.v1.user.getMetadata();
   if (!md) { return; }
   for (var i = 0; i < md.length; i++) {
     if (md[i].key === "collections") {
-      try {
-        api.v1.claims.setClaim("collections", JSON.parse(atob(md[i].value)));
-      } catch (e) {}
+      api.v1.claims.setClaim("collections", md[i].value);
       break;
     }
   }
@@ -221,8 +220,8 @@ def main():
         action_id = action["id"]
         print(f"  action_id={action_id}")
 
-        # Flow type 2 = CUSTOMISE_TOKEN, trigger type 4 = PRE_ACCESS_TOKEN_CREATION
-        api(client, "post", "/management/v1/flows/2/trigger/4", json={"actionIds": [action_id]})
+        # Flow type 2 = CUSTOMISE_TOKEN, trigger type 5 = PRE_ACCESS_TOKEN_CREATION
+        api(client, "post", "/management/v1/flows/2/trigger/5", json={"actionIds": [action_id]})
         print("  trigger set (CUSTOMISE_TOKEN / PRE_ACCESS_TOKEN_CREATION)")
 
         # ── Human users ───────────────────────────────────────────────────────

--- a/spa/docker-entrypoint.sh
+++ b/spa/docker-entrypoint.sh
@@ -38,6 +38,8 @@ else
 fi
 
 COMPUTED_OIDC_CLIENT_ID="${OIDC_CLIENT_ID:-${KEYCLOAK_CLIENT_ID:-$DEFAULT_KEYCLOAK_CLIENT_ID}}"
+COMPUTED_OIDC_SCOPE="${OIDC_SCOPE:-openid profile email stuf:access}"
+COMPUTED_OIDC_LOAD_USER_INFO="${OIDC_LOAD_USER_INFO:-false}"
 
 # Determine the mode (dev or prod) - default to prod
 MODE="${1:-prod}"
@@ -59,7 +61,9 @@ cat > "$CONFIG_PATH" <<EOF
 window.__STUF_CONFIG__ = {
   apiBaseUrl: "$API_BASE_URL",
   oidcAuthority: "$COMPUTED_OIDC_AUTHORITY",
-  oidcClientId: "$COMPUTED_OIDC_CLIENT_ID"
+  oidcClientId: "$COMPUTED_OIDC_CLIENT_ID",
+  oidcScope: "$COMPUTED_OIDC_SCOPE",
+  oidcLoadUserInfo: $COMPUTED_OIDC_LOAD_USER_INFO
 };
 EOF
 
@@ -67,6 +71,8 @@ echo "Generated runtime configuration at $CONFIG_PATH:"
 echo "  API Base URL: $API_BASE_URL"
 echo "  OIDC Authority: $COMPUTED_OIDC_AUTHORITY"
 echo "  OIDC Client ID: $COMPUTED_OIDC_CLIENT_ID"
+echo "  OIDC Scope: $COMPUTED_OIDC_SCOPE"
+echo "  OIDC Load User Info: $COMPUTED_OIDC_LOAD_USER_INFO"
 echo "  Port: $SPA_PORT"
 
 # Start the appropriate server based on mode

--- a/spa/src/config.test.ts
+++ b/spa/src/config.test.ts
@@ -34,18 +34,20 @@ describe("getConfig", () => {
 
     expect(config).toEqual({
       apiBaseUrl: "http://localhost:8000",
-      keycloakUrl: "http://localhost:8080",
-      keycloakRealm: "stuf",
-      keycloakClientId: "stuf-spa",
+      oidcAuthority: "http://localhost:8080/realms/stuf",
+      oidcClientId: "stuf-spa",
+      oidcScope: "openid profile email stuf:access",
+      oidcLoadUserInfo: false,
     });
   });
 
   it("returns runtime config when window.__STUF_CONFIG__ is set", async () => {
     const runtimeConfig: StufConfig = {
       apiBaseUrl: "https://api.example.com",
-      keycloakUrl: "https://auth.example.com",
-      keycloakRealm: "production",
-      keycloakClientId: "prod-client",
+      oidcAuthority: "https://auth.example.com",
+      oidcClientId: "prod-client",
+      oidcScope: "openid profile email stuf:access",
+      oidcLoadUserInfo: false,
     };
 
     window.__STUF_CONFIG__ = runtimeConfig;
@@ -74,9 +76,10 @@ describe("getConfig", () => {
   it("caches the config after first call", () => {
     const runtimeConfig: StufConfig = {
       apiBaseUrl: "https://api.example.com",
-      keycloakUrl: "https://auth.example.com",
-      keycloakRealm: "production",
-      keycloakClientId: "prod-client",
+      oidcAuthority: "https://auth.example.com",
+      oidcClientId: "prod-client",
+      oidcScope: "openid profile email stuf:access",
+      oidcLoadUserInfo: false,
     };
 
     window.__STUF_CONFIG__ = runtimeConfig;
@@ -91,9 +94,10 @@ describe("getConfig", () => {
   it("does not log warning when runtime config is set", async () => {
     const runtimeConfig: StufConfig = {
       apiBaseUrl: "https://api.example.com",
-      keycloakUrl: "https://auth.example.com",
-      keycloakRealm: "production",
-      keycloakClientId: "prod-client",
+      oidcAuthority: "https://auth.example.com",
+      oidcClientId: "prod-client",
+      oidcScope: "openid profile email stuf:access",
+      oidcLoadUserInfo: false,
     };
 
     window.__STUF_CONFIG__ = runtimeConfig;

--- a/spa/src/config.ts
+++ b/spa/src/config.ts
@@ -13,12 +13,16 @@ export interface StufConfig {
   apiBaseUrl: string;
   oidcAuthority: string;
   oidcClientId: string;
+  oidcScope: string;
+  oidcLoadUserInfo: boolean;
 }
 
 const DEFAULTS: StufConfig = {
   apiBaseUrl: "http://localhost:8000",
   oidcAuthority: "http://localhost:8080/realms/stuf",
   oidcClientId: "stuf-spa",
+  oidcScope: "openid profile email stuf:access",
+  oidcLoadUserInfo: false,
 };
 
 let configCache: StufConfig | null = null;

--- a/spa/src/hooks/user/useUser.test.ts
+++ b/spa/src/hooks/user/useUser.test.ts
@@ -1,23 +1,39 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { renderHook } from "@testing-library/react";
+import { renderHook, waitFor } from "@testing-library/react";
 import { useUser } from "./useUser";
 import { useAuth } from "react-oidc-context";
+import apiClient from "@/services/api";
 import type { User as OidcUser } from "oidc-client-ts";
 import type { AuthContextProps } from "react-oidc-context";
 
-// Mock react-oidc-context
 vi.mock("react-oidc-context", () => ({
   useAuth: vi.fn(),
 }));
 
-// Helper function to create mock auth context
+vi.mock("@/services/api", () => ({
+  default: {
+    request: vi.fn(),
+  },
+}));
+
 function createMockAuth(user?: OidcUser | null): AuthContextProps {
-  return { user } as unknown as AuthContextProps;
+  return {
+    user,
+    isAuthenticated: !!(user?.access_token),
+  } as unknown as AuthContextProps;
 }
+
+const BASE_PROFILE = {
+  preferred_username: "johndoe",
+  given_name: "John",
+  family_name: "Doe",
+  email: "john.doe@example.com",
+};
 
 describe("useUser", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(apiClient.request).mockResolvedValue({ collections: {} });
   });
 
   describe("when user is not authenticated", () => {
@@ -49,32 +65,30 @@ describe("useUser", () => {
   });
 
   describe("when user is authenticated", () => {
-    it("returns user with full name when given_name and family_name are present", () => {
+    it("returns user with full name and collections from /api/me", async () => {
+      const mockCollections = {
+        "collection-1": ["read", "write"],
+        "collection-2": ["read"],
+      };
+      vi.mocked(apiClient.request).mockResolvedValue({ collections: mockCollections });
       vi.mocked(useAuth).mockReturnValue(
         createMockAuth({
-          profile: {
-            preferred_username: "johndoe",
-            given_name: "John",
-            family_name: "Doe",
-            email: "john.doe@example.com",
-            collections: {
-              "collection-1": ["read", "write"],
-              "collection-2": ["read"],
-            },
-          },
+          profile: BASE_PROFILE,
+          access_token: "test-token",
         } as unknown as OidcUser),
       );
 
       const { result } = renderHook(() => useUser());
 
+      await waitFor(() => {
+        expect(result.current?.collections).toEqual(mockCollections);
+      });
+
       expect(result.current).toEqual({
         username: "johndoe",
         name: "John Doe",
         email: "john.doe@example.com",
-        collections: {
-          "collection-1": ["read", "write"],
-          "collection-2": ["read"],
-        },
+        collections: mockCollections,
         roles: [],
       });
     });
@@ -86,7 +100,6 @@ describe("useUser", () => {
             family_name: "Doe",
             preferred_username: "johndoe",
             email: "john.doe@example.com",
-            collections: {},
           },
         } as unknown as OidcUser),
       );
@@ -104,7 +117,6 @@ describe("useUser", () => {
             given_name: "John",
             preferred_username: "johndoe",
             email: "john.doe@example.com",
-            collections: {},
           },
         } as unknown as OidcUser),
       );
@@ -121,7 +133,6 @@ describe("useUser", () => {
           profile: {
             preferred_username: "johndoe",
             email: "john.doe@example.com",
-            collections: {},
           },
         } as unknown as OidcUser),
       );
@@ -137,7 +148,6 @@ describe("useUser", () => {
         createMockAuth({
           profile: {
             email: "user@example.com",
-            collections: {},
           },
         } as unknown as OidcUser),
       );
@@ -154,7 +164,6 @@ describe("useUser", () => {
           profile: {
             given_name: "John",
             family_name: "Doe",
-            collections: {},
           },
         } as unknown as OidcUser),
       );
@@ -164,7 +173,7 @@ describe("useUser", () => {
       expect(result.current?.email).toBe("");
     });
 
-    it("handles missing collections field", () => {
+    it("returns empty collections when no access token", () => {
       vi.mocked(useAuth).mockReturnValue(
         createMockAuth({
           profile: {
@@ -177,22 +186,23 @@ describe("useUser", () => {
 
       const { result } = renderHook(() => useUser());
 
-      expect(result.current?.collections).toBeUndefined();
+      expect(result.current?.collections).toEqual({});
     });
 
-    it("handles empty collections object", () => {
+    it("returns empty collections when /api/me call fails", async () => {
+      vi.mocked(apiClient.request).mockRejectedValue(new Error("Network error"));
       vi.mocked(useAuth).mockReturnValue(
         createMockAuth({
-          profile: {
-            given_name: "John",
-            family_name: "Doe",
-            email: "john.doe@example.com",
-            collections: {},
-          },
+          profile: BASE_PROFILE,
+          access_token: "test-token",
         } as unknown as OidcUser),
       );
 
       const { result } = renderHook(() => useUser());
+
+      await waitFor(() => {
+        expect(vi.mocked(apiClient.request)).toHaveBeenCalled();
+      });
 
       expect(result.current?.collections).toEqual({});
     });
@@ -204,8 +214,6 @@ describe("useUser", () => {
             given_name: "John",
             family_name: "Doe",
             email: "john.doe@example.com",
-            collections: {},
-            roles: ["admin", "user"], // Even if present in profile
           },
         } as unknown as OidcUser),
       );
@@ -215,28 +223,24 @@ describe("useUser", () => {
       expect(result.current?.roles).toEqual([]);
     });
 
-    it("handles complex collection permissions structure", () => {
+    it("fetches complex collection permissions from /api/me", async () => {
+      const mockCollections = {
+        "project-alpha": ["read", "write", "delete"],
+        "project-beta": ["read"],
+        "project-gamma": ["read", "write"],
+      };
+      vi.mocked(apiClient.request).mockResolvedValue({ collections: mockCollections });
       vi.mocked(useAuth).mockReturnValue(
         createMockAuth({
-          profile: {
-            given_name: "John",
-            family_name: "Doe",
-            email: "john.doe@example.com",
-            collections: {
-              "project-alpha": ["read", "write", "delete"],
-              "project-beta": ["read"],
-              "project-gamma": ["read", "write"],
-            },
-          },
+          profile: BASE_PROFILE,
+          access_token: "test-token",
         } as unknown as OidcUser),
       );
 
       const { result } = renderHook(() => useUser());
 
-      expect(result.current?.collections).toEqual({
-        "project-alpha": ["read", "write", "delete"],
-        "project-beta": ["read"],
-        "project-gamma": ["read", "write"],
+      await waitFor(() => {
+        expect(result.current?.collections).toEqual(mockCollections);
       });
     });
   });

--- a/spa/src/hooks/user/useUser.ts
+++ b/spa/src/hooks/user/useUser.ts
@@ -1,21 +1,23 @@
-import { useMemo } from "react";
+import { useState, useEffect, useMemo } from "react";
 import { useAuth } from "react-oidc-context";
+import apiClient from "@/services/api";
 import type { User } from "@/types";
 
-function parseCollections(profile: Record<string, unknown>): Record<string, string[]> {
-  const direct = profile?.collections;
-  if (direct !== undefined && direct !== null) {
-    return (typeof direct === "string" ? JSON.parse(direct) : direct) as Record<string, string[]>;
-  }
-  return {} as Record<string, string[]>;
-}
-
-/**
- * Hook to get user info from auth context
- * Parses the JWT token profile and returns a User object
- */
 export function useUser(): User | null {
   const auth = useAuth();
+  const [collections, setCollections] = useState<Record<string, string[]>>({});
+
+  useEffect(() => {
+    if (!auth.isAuthenticated || !auth.user?.access_token) {
+      setCollections({});
+      return;
+    }
+
+    apiClient
+      .request("/api/me")
+      .then((data) => setCollections(data.collections ?? {}))
+      .catch(() => setCollections({}));
+  }, [auth.isAuthenticated, auth.user?.access_token]);
 
   return useMemo(() => {
     if (!auth.user?.profile) {
@@ -26,14 +28,14 @@ export function useUser(): User | null {
     const username = (profile?.preferred_username as string) || "";
 
     return {
-      username, // standard OIDC preferred_username - matches backend user.username
+      username,
       name:
         profile?.given_name && profile?.family_name
           ? `${profile.given_name} ${profile.family_name}`
           : username || "Unknown User",
       email: (profile?.email as string) || "",
-      collections: parseCollections(profile),
-      roles: [], // Roles not currently used - permissions are collection-based
+      collections,
+      roles: [],
     };
-  }, [auth.user]);
+  }, [auth.user, collections]);
 }

--- a/spa/src/hooks/user/useUser.ts
+++ b/spa/src/hooks/user/useUser.ts
@@ -15,8 +15,8 @@ function parseCollections(profile: Record<string, unknown>): Record<string, stri
       if (entry.collections !== undefined) {
         try {
           return JSON.parse(atob(entry.collections)) as Record<string, string[]>;
-        } catch {
-          // ignore decode errors
+        } catch (e) {
+          console.warn("Failed to decode Zitadel metadata collections entry:", e);
         }
       }
     }

--- a/spa/src/hooks/user/useUser.ts
+++ b/spa/src/hooks/user/useUser.ts
@@ -2,6 +2,28 @@ import { useMemo } from "react";
 import { useAuth } from "react-oidc-context";
 import type { User } from "@/types";
 
+function parseCollections(profile: Record<string, unknown>): Record<string, string[]> {
+  // Direct claim (Keycloak mapper or Zitadel action when metadataList is available)
+  const direct = profile?.collections;
+  if (direct !== undefined && direct !== null) {
+    return (typeof direct === "string" ? JSON.parse(direct) : direct) as Record<string, string[]>;
+  }
+  // Zitadel native metadata scope: urn:zitadel:iam:user:metadata is an array of {key: base64_value}
+  const zitadelMd = profile?.["urn:zitadel:iam:user:metadata"];
+  if (Array.isArray(zitadelMd)) {
+    for (const entry of zitadelMd as Array<Record<string, string>>) {
+      if (entry.collections !== undefined) {
+        try {
+          return JSON.parse(atob(entry.collections)) as Record<string, string[]>;
+        } catch {
+          // ignore decode errors
+        }
+      }
+    }
+  }
+  return {} as Record<string, string[]>;
+}
+
 /**
  * Hook to get user info from auth context
  * Parses the JWT token profile and returns a User object
@@ -24,7 +46,7 @@ export function useUser(): User | null {
           ? `${profile.given_name} ${profile.family_name}`
           : username || "Unknown User",
       email: (profile?.email as string) || "",
-      collections: profile?.collections as Record<string, string[]>,
+      collections: parseCollections(profile),
       roles: [], // Roles not currently used - permissions are collection-based
     };
   }, [auth.user]);

--- a/spa/src/hooks/user/useUser.ts
+++ b/spa/src/hooks/user/useUser.ts
@@ -3,23 +3,9 @@ import { useAuth } from "react-oidc-context";
 import type { User } from "@/types";
 
 function parseCollections(profile: Record<string, unknown>): Record<string, string[]> {
-  // Direct claim (Keycloak mapper or Zitadel action when metadataList is available)
   const direct = profile?.collections;
   if (direct !== undefined && direct !== null) {
     return (typeof direct === "string" ? JSON.parse(direct) : direct) as Record<string, string[]>;
-  }
-  // Zitadel native metadata scope: urn:zitadel:iam:user:metadata is an array of {key: base64_value}
-  const zitadelMd = profile?.["urn:zitadel:iam:user:metadata"];
-  if (Array.isArray(zitadelMd)) {
-    for (const entry of zitadelMd as Array<Record<string, string>>) {
-      if (entry.collections !== undefined) {
-        try {
-          return JSON.parse(atob(entry.collections)) as Record<string, string[]>;
-        } catch (e) {
-          console.warn("Failed to decode Zitadel metadata collections entry:", e);
-        }
-      }
-    }
   }
   return {} as Record<string, string[]>;
 }

--- a/spa/src/index.tsx
+++ b/spa/src/index.tsx
@@ -5,7 +5,7 @@ import { getConfig } from "./config";
 import { ThemeProvider } from "./contexts/ThemeContext";
 import "./index.css";
 
-const { oidcAuthority, oidcClientId } = getConfig();
+const { oidcAuthority, oidcClientId, oidcScope, oidcLoadUserInfo } = getConfig();
 
 const oidcConfig = {
   authority: oidcAuthority,
@@ -13,7 +13,8 @@ const oidcConfig = {
   redirect_uri: window.location.origin,
   post_logout_redirect_uri: window.location.origin,
   response_type: "code",
-  scope: "openid profile email stuf:access",
+  scope: oidcScope,
+  loadUserInfo: oidcLoadUserInfo,
   automaticSilentRenew: true,
   includeIdTokenInSilentRenew: true,
   // Use default storage (localStorage) - works fine for most cases

--- a/tasks/0001-support-zitadel-as-oidc-provider.md
+++ b/tasks/0001-support-zitadel-as-oidc-provider.md
@@ -494,6 +494,91 @@ These need decisions or upstream investigation before implementation:
    already in `login_page.py`.  ROPC is no longer used anywhere in the test
    suite.
 
+10. **Can the `complement_token` / `pre_access_token_creation` flow simplify
+    collection delivery?** *(Resolved — 2026-05-06: yes, all three code paths can collapse to one)*
+
+    **Context:** STUF's core requirement is that each user and service account
+    carries a `collections` claim in their JWT (see [issue #96][i96] for the
+    full picture, including how Keycloak and Zitadel handle this today).
+
+    The current Zitadel implementation has three separate code paths where
+    Keycloak needs only one:
+
+    | Path | Owner |
+    |------|-------|
+    | `collections` injected by Keycloak scope mapper → access token | API middleware reads `token_payload["collections"]` directly |
+    | `urn:zitadel:iam:user:metadata` in Zitadel userinfo response | `useUser.ts` `parseCollections()` fallback decodes base64 metadata |
+    | Machine user tokens carry no claim at all | API middleware falls back to role-name encoding or `STUF_MACHINE_USER_COLLECTIONS` env var |
+
+    The earlier comments in `provision.py` claimed `setClaim` (flow 2,
+    `PRE_USERINFO_CREATION`, trigger 4) "only affects the userinfo endpoint
+    response, not access or ID tokens; and the trigger does not fire at all
+    for `client_credentials` grants." That claim was correct *for trigger 4*
+    but missed that **a sibling trigger `PRE_ACCESS_TOKEN_CREATION` (flow 2,
+    trigger 5) does exactly what we need.**
+
+    **Resolution.** Confirmed empirically against `ghcr.io/zitadel/zitadel:v4.14.0`
+    (registered the action, ran it, decoded resulting JWTs):
+
+    - `PRE_ACCESS_TOKEN_CREATION` is registered via
+      `POST /management/v1/flows/2/trigger/5` and accepted without
+      "TriggerType is invalid".
+    - It fires during access-token creation for **both** authorization-code
+      grants (human users) and `client_credentials` grants (machine users),
+      provided the project's access-token type is JWT — which STUF already
+      sets via `accessTokenType: "OIDC_TOKEN_TYPE_JWT"` on the API app, plus
+      `accessTokenRoleAssertion: True` on the SPA app.
+    - `ctx.v1.user` is populated for both human and machine users; `sub`
+      maps to the right user id in both cases.
+    - `ctx.v1.user.getMetadata()` returns the user's metadata array (works
+      for human and machine users alike). Each entry's `value` arrives as a
+      JSON-decoded object when the stored bytes are valid JSON, so
+      `api.v1.claims.setClaim("collections", entry.value)` is sufficient —
+      no `atob`/JSON.parse dance, and `atob` is in fact not defined in
+      Zitadel's goja runtime.
+    - The injected claim appears verbatim in the access token (for both
+      grants) at the top level — matching Keycloak's `collections` claim
+      shape exactly. Sample machine-user payload after the action ran:
+      `{"sub":"...","client_id":"backup-service","collections":{"shared":["read"],"test":["read"]},...}`.
+
+    Source-level confirmation (zitadel `v4.14.0`):
+    `internal/api/oidc/userinfo.go` runs both v1 and v2 actions through one
+    `userinfoFlows` function regardless of grant type;
+    `internal/api/oidc/token_client_credentials.go` confirms the
+    `client_credentials` path reaches `createJWT` which invokes the
+    trigger. Trigger enums live in `internal/domain/flow.go`.
+
+    **Implication for STUF.** The three divergent paths collapse to one:
+
+    - `provision.py` registers a single action body that calls
+      `setClaim("collections", entry.value)` and binds it to flow 2,
+      trigger 5 (replace the existing trigger-4 binding).
+    - `api/auth/middleware.py` always reads `token_payload["collections"]`
+      directly (matches Keycloak's path; remove the `STUF_MACHINE_USER_COLLECTIONS`
+      env-var fallback and any role-name decoding).
+    - `spa/src/hooks/user/useUser.ts` reads `auth.user.profile.collections`
+      with no Zitadel-specific fallback (drop `parseCollections()` /
+      `urn:zitadel:iam:user:metadata` handling; userinfo no longer needs
+      to be loaded for the SPA at all, so `oidcLoadUserInfo` can stay false).
+    - `STUF_MACHINE_USER_COLLECTIONS` and the per-client-id base64 map
+      written to `generated.env` become dead code and can be deleted.
+    - The `urn:zitadel:iam:user:metadata` scope is no longer required for
+      collection delivery (it remains harmless if requested).
+
+    **Out-of-scope quirk noted while testing.** Zitadel's
+    `POST /v2/sessions` `password.password` check returned
+    `"User has not set a password"` for users created via `/v2/users/human`
+    despite a password being supplied — `admin@stuf.localhost` (created via
+    `ZITADEL_FIRSTINSTANCE_*`) authenticates fine. The browser-based login
+    used by the e2e suite still works for these users, so this is a separate
+    provisioning concern, not a blocker for the trigger-5 migration.
+
+    Repro scripts are in `/tmp/zitadel-probe/` (not committed): `probe2.py`
+    drives the action update + machine-user JWT inspection, `probe_human3.py`
+    drives the human-user authorization-code flow via the v2 session API.
+
+[i96]: https://github.com/pyx-industries/stuf/issues/96
+
 ## Suggested implementation order
 
 Once the open questions above are answered, a low-risk sequence is:

--- a/tasks/0002-spa-collections-from-access-token.md
+++ b/tasks/0002-spa-collections-from-access-token.md
@@ -1,0 +1,139 @@
+# SPA collections claim: fetch from API instead of decoding tokens
+
+## Problem
+
+`useUser.ts` reads `collections` from `auth.user.profile.collections`. In
+`oidc-client-ts` the `profile` is built from the **ID token** (when
+`loadUserInfo: false`) or from the **userinfo endpoint response** (when
+`loadUserInfo: true`).
+
+**Keycloak** — works today because the `stuf:access` scope mapper is configured
+with `id.token.claim: true`, `access.token.claim: true`, and
+`userinfo.token.claim: true` simultaneously. `collections` appears in all three.
+The SPA defaults to `OIDC_LOAD_USER_INFO=false` for Keycloak, so the profile
+comes from the ID token, which has the claim.
+
+**Zitadel** — the `PRE_ACCESS_TOKEN_CREATION` action (trigger 5) injects
+`collections` into the **access token only**. The ID token is created
+separately and does not receive custom action claims. The userinfo endpoint
+response is driven by granted scopes, not by the access-token payload, so it
+returns `urn:zitadel:iam:user:metadata` when that scope is requested but never
+a top-level `collections` claim. The Makefile therefore sets
+`OIDC_LOAD_USER_INFO=true` for Zitadel, but the userinfo response still does
+not contain `collections`.
+
+**Consequence of the branch-5a simplification:** the
+`urn:zitadel:iam:user:metadata` fallback was removed from `parseCollections()`
+in `useUser.ts`. That fallback was the only way the SPA had previously been
+able to surface collections under Zitadel. Removing it broke the browser BDD
+test `test_file_upload_bdd.py::test_upload_a_valid_file_into_a_collection`
+(assertion: "Could not find collection 'test'" because the SPA showed no
+collections for the logged-in admin user).
+
+The service-account tests all pass — the API reads `collections` directly from
+the JWT access token, which trigger 5 populates correctly. The gap is
+SPA-only.
+
+## Key observation
+
+The `/api/me` endpoint already exists and returns `collections` in its response
+(alongside `username`, `email`, `full_name`, `roles`, `active`). The API reads
+`collections` directly from the validated access token, which is the one place
+both providers always have the claim:
+
+| Token / endpoint      | Keycloak | Zitadel (trigger 5) |
+|-----------------------|----------|---------------------|
+| Access token          | ✓        | ✓                   |
+| ID token              | ✓        | ✗                   |
+| Userinfo response     | ✓        | ✗                   |
+
+The SPA can call `/api/me` on login to get collections rather than trying to
+extract them from the OIDC token or profile — removing all token-decoding logic
+from the SPA and keeping the API as the single authoritative source.
+
+## Options
+
+### Option A — Read `collections` from the decoded access token
+
+Change `useUser.ts` to decode `auth.user.access_token` and read `collections`
+from its payload, while continuing to read `username`, `email`, `name`, etc.
+from `auth.user.profile` (ID token / userinfo) as today.
+
+**Pros:**
+- Single provider-agnostic code path — no Keycloak / Zitadel branches
+- `OIDC_LOAD_USER_INFO` can revert to `false` for Zitadel
+- No extra network round-trip
+
+**Cons:**
+- Decoding the access token in the SPA is slightly unusual (it is opaque in
+  some architectures)
+- Still requires provider-specific knowledge to know which token holds the claim
+
+### Option B — Bind a second action to the Zitadel userinfo flow
+
+Register an additional action on the Zitadel userinfo flow so that when the
+userinfo endpoint is called, `collections` is also injected into the response.
+
+**Pros:** `useUser.ts` continues reading from `profile.collections` unchanged
+
+**Cons:**
+- Two action registrations in `provision.py` (one for access-token, one for
+  userinfo)
+- The userinfo flow context may have a different shape from the access-token
+  flow context (needs its own investigation)
+- `OIDC_LOAD_USER_INFO=true` must remain set for Zitadel
+- More moving parts for equivalent result
+
+### Option C — Restore the `urn:zitadel:iam:user:metadata` fallback
+
+Re-add the `urn:zitadel:iam:user:metadata` parsing to `parseCollections()` in
+`useUser.ts`, and keep the `urn:zitadel:iam:user:metadata` scope in the Zitadel
+OIDC scope string.
+
+**Pros:** Minimal change; well-understood path
+
+**Cons:**
+- Reverts the "collapse to one path" goal from branch 5a
+- Keeps Zitadel-specific logic in the SPA
+- The metadata value returned by the userinfo endpoint is still base64-encoded
+  JSON (the userinfo endpoint does not decode it the way the action context
+  does), so the decoding chain (`atob` + `JSON.parse`) must remain
+
+### Option D — Fetch collections from `/api/me` (recommended)
+
+On login (when `auth.isAuthenticated` becomes true), call `GET /api/me` with
+the access token as a Bearer header. Store the returned `collections` in React
+state alongside the other user fields.
+
+**Pros:**
+- The SPA never decodes or inspects tokens — clean separation of concerns
+- Removes all provider-specific collection logic from the SPA entirely
+- The API is the single authoritative source (it already validates the token
+  and resolves collections for every other endpoint)
+- `OIDC_LOAD_USER_INFO` can revert to `false` for both providers; no userinfo
+  call needed at all
+- `parseCollections()` and all related token-inspection code can be deleted
+
+**Cons:**
+- One extra network round-trip on login (minor; `/api/me` is cheap)
+
+## Recommended path
+
+Option D. The `/api/me` endpoint already returns `collections`; using it
+removes all token-decoding logic from the SPA, eliminates provider-specific
+branching, and keeps the API as the single source of truth for authorization
+data. Combine with:
+
+- Removing `parseCollections()` and the `collections` extraction from
+  `useUser.ts`
+- Reverting `OIDC_LOAD_USER_INFO` to `false` for Zitadel in the Makefile and
+  docker-compose, since the userinfo call is no longer needed
+
+## Where to implement
+
+**Branch: `85-zitadel-5a` (PR #93).** The regression was introduced there when
+`parseCollections()` was simplified in `useUser.ts`. The SPA OIDC env-var
+changes (`OIDC_LOAD_USER_INFO`, `OIDC_SCOPE`) are also in 5a. Fixing it there
+means 5b and 5c (which build on top of 5a) inherit the correct behaviour
+automatically, and the Zitadel browser E2E tests added in 5c should pass
+without any further changes.

--- a/tests/e2e-browser/config.py
+++ b/tests/e2e-browser/config.py
@@ -39,4 +39,4 @@ SPA_HOST = get_spa_host()
 
 # Default credentials
 DEFAULT_USERNAME = "admin@example.com"
-DEFAULT_PASSWORD = "password"
+DEFAULT_PASSWORD = "Password1!"

--- a/tests/e2e-browser/conftest.py
+++ b/tests/e2e-browser/conftest.py
@@ -127,34 +127,13 @@ def authenticated_page(page):
     except Exception as e:
         raise RuntimeError(f"Failed to start login flow: {e}")
 
-    # Fill in login form
+    # Complete the login using the provider-agnostic LoginPage abstraction.
+    # This handles both Keycloak (single-step) and Zitadel (two-step) flows.
     try:
-        # Wait for login form
-        page.wait_for_selector('input[name="username"]', timeout=10000)
-        page.wait_for_selector('input[name="password"]', timeout=5000)
+        from pages.login_page import LoginPage
 
-        # Fill credentials
-        page.fill('input[name="username"]', "admin@example.com")
-        page.fill('input[name="password"]', "password")
-
-        # Submit
-        page.click('button[type="submit"]')
-
-        # Wait for redirect back to SPA (more flexible)
-        max_attempts = 15
-        for attempt in range(max_attempts):
-            page.wait_for_timeout(1000)
-            current_url = page.url
-            if SPA_HOST in current_url:
-                break
-        else:
-            raise RuntimeError(
-                f"Not redirected to SPA after login. Current URL: {page.url}"
-            )
-
-        # Give time for React to process the auth callback
-        page.wait_for_timeout(3000)
-
+        login_page = LoginPage(page)
+        login_page.login_with_admin_user()
     except Exception as e:
         raise RuntimeError(f"Login flow failed: {e}")
 
@@ -209,17 +188,17 @@ def test_data():
         "users": {
             "admin": {
                 "username": "admin@example.com",
-                "password": "password",
+                "password": "Password1!",
                 "role": "admin",
             },
             "user": {
                 "username": "testuser@example.com",
-                "password": "password",
+                "password": "Password1!",
                 "role": "user",
             },
             "limited": {
                 "username": "limiteduser@example.com",
-                "password": "password",
+                "password": "Password1!",
                 "role": "limited",
             },
         },

--- a/tests/e2e-browser/pages/login_page.py
+++ b/tests/e2e-browser/pages/login_page.py
@@ -111,15 +111,15 @@ class LoginPage(BasePage):
 
     def login_with_admin_user(self) -> None:
         """Login with default admin user credentials."""
-        self.login("admin@example.com", "Password1!" if self._is_zitadel() else "password")
+        self.login("admin@example.com", "Password1!")
 
     def login_with_test_user(self) -> None:
         """Login with default test user credentials."""
-        self.login("testuser@example.com", "password")
+        self.login("testuser@example.com", "Password1!")
 
     def login_with_limited_user(self) -> None:
         """Login with limited user credentials."""
-        self.login("limiteduser@example.com", "password")
+        self.login("limiteduser@example.com", "Password1!")
 
     def assert_login_form_visible(self) -> None:
         """Assert that the login form is visible."""

--- a/tests/e2e-browser/step_definitions/authentication_steps.py
+++ b/tests/e2e-browser/step_definitions/authentication_steps.py
@@ -101,29 +101,19 @@ def redirected_to_login(page: Page, bdd_screenshot_helper):
 
 @when("I enter valid admin credentials")
 def enter_valid_admin_credentials(page: Page, bdd_screenshot_helper):
-    """Enter valid admin credentials."""
+    """Enter valid admin credentials (provider-agnostic)."""
     login_page = LoginPage(page)
+    login_page.wait_for_login_form()
 
-    # Use more explicit interaction - click and type rather than just fill
-    page.click('input[name="username"]')
-    page.type('input[name="username"]', "admin@example.com")
-
-    page.click('input[name="password"]')
-    page.type('input[name="password"]', "password")
-
-    # Wait for visual updates to complete
-    page.wait_for_timeout(1000)
-
-    # Verify both fields show content (username text, password asterisks)
-    page.wait_for_function("""
-        () => {
-            const usernameInput = document.querySelector('input[name="username"]');
-            const passwordInput = document.querySelector('input[name="password"]');
-            return usernameInput && passwordInput &&
-                   usernameInput.value.length > 0 &&
-                   passwordInput.value.length > 0;
-        }
-    """)
+    if login_page._is_zitadel():
+        # Two-step: login name → Next → password (don't submit final step yet)
+        login_page.fill_input(login_page.ZD_LOGINNAME_INPUT, "admin@example.com")
+        login_page.click_element(login_page.ZD_SUBMIT_BUTTON)
+        login_page.wait_for_selector(login_page.ZD_PASSWORD_INPUT, timeout=10000)
+        login_page.fill_input(login_page.ZD_PASSWORD_INPUT, "Password1!")
+    else:
+        login_page.fill_input(login_page.KC_USERNAME_INPUT, "admin@example.com")
+        login_page.fill_input(login_page.KC_PASSWORD_INPUT, "Password1!")
 
     bdd_screenshot_helper.take_bdd_screenshot(
         login_page, "credentials-entered", "And I enter valid admin credentials"
@@ -132,29 +122,22 @@ def enter_valid_admin_credentials(page: Page, bdd_screenshot_helper):
 
 @when("I enter invalid credentials")
 def enter_invalid_credentials(page: Page, bdd_screenshot_helper):
-    """Enter invalid credentials."""
+    """Enter invalid credentials (provider-agnostic)."""
     login_page = LoginPage(page)
+    login_page.wait_for_login_form()
 
-    # Use more explicit interaction - click and type rather than just fill
-    page.click('input[name="username"]')
-    page.type('input[name="username"]', "invalid@example.com")
-
-    page.click('input[name="password"]')
-    page.type('input[name="password"]', "wrongpassword")
-
-    # Wait for visual updates to complete
-    page.wait_for_timeout(1000)
-
-    # Verify both fields show content (username text, password asterisks)
-    page.wait_for_function("""
-        () => {
-            const usernameInput = document.querySelector('input[name="username"]');
-            const passwordInput = document.querySelector('input[name="password"]');
-            return usernameInput && passwordInput &&
-                   usernameInput.value.length > 0 &&
-                   passwordInput.value.length > 0;
-        }
-    """)
+    if login_page._is_zitadel():
+        # Two-step: login name → Next → password (unknown user may fail at step 1)
+        login_page.fill_input(login_page.ZD_LOGINNAME_INPUT, "invalid@example.com")
+        login_page.click_element(login_page.ZD_SUBMIT_BUTTON)
+        try:
+            login_page.wait_for_selector(login_page.ZD_PASSWORD_INPUT, timeout=5000)
+            login_page.fill_input(login_page.ZD_PASSWORD_INPUT, "wrongpassword")
+        except Exception:
+            pass  # Unknown user may have already shown an error at the login-name step
+    else:
+        login_page.fill_input(login_page.KC_USERNAME_INPUT, "invalid@example.com")
+        login_page.fill_input(login_page.KC_PASSWORD_INPUT, "wrongpassword")
 
     bdd_screenshot_helper.take_bdd_screenshot(
         login_page, "invalid-credentials-entered", "And I enter invalid credentials"
@@ -224,41 +207,34 @@ def login_as_user_type(page: Page, user_type: str, bdd_screenshot_helper):
     login_page = LoginPage(page)
     login_page.wait_for_login_form()
 
-    if user_type.lower() == "regular":
-        login_page.fill_username("testuser@example.com")
-        login_page.fill_password("password")
-        # Take screenshot before clicking login to show the filled form
-        bdd_screenshot_helper.take_bdd_screenshot(
-            login_page,
-            f"login-form-filled-{user_type.lower()}",
-            f'When I log in as a "{user_type}" user',
-        )
-        login_page.click_login()
-    elif user_type.lower() == "admin":
-        login_page.fill_username("admin@example.com")
-        login_page.fill_password("password")
-        # Take screenshot before clicking login to show the filled form
-        bdd_screenshot_helper.take_bdd_screenshot(
-            login_page,
-            f"login-form-filled-{user_type.lower()}",
-            f'When I log in as a "{user_type}" user',
-        )
-        login_page.click_login()
-    elif user_type.lower() == "limited":
-        login_page.fill_username("limiteduser@example.com")
-        login_page.fill_password("password")
-        # Take screenshot before clicking login to show the filled form
-        bdd_screenshot_helper.take_bdd_screenshot(
-            login_page,
-            f"login-form-filled-{user_type.lower()}",
-            f'When I log in as a "{user_type}" user',
-        )
-        login_page.click_login()
-    else:
+    credentials = {
+        "regular": ("testuser@example.com", "Password1!"),
+        "admin": ("admin@example.com", "Password1!"),
+        "limited": ("limiteduser@example.com", "Password1!"),
+    }
+    if user_type.lower() not in credentials:
         raise ValueError(f"Unknown user type: {user_type}")
 
+    username, password = credentials[user_type.lower()]
+    login_page.fill_username(username)
+    if login_page._is_zitadel():
+        # Zitadel two-step: advance from login-name page to password page
+        login_page.click_login()
+        login_page.wait_for_selector(login_page.ZD_PASSWORD_INPUT, timeout=10000)
+    login_page.fill_password(password)
+    bdd_screenshot_helper.take_bdd_screenshot(
+        login_page,
+        f"login-form-filled-{user_type.lower()}",
+        f'When I log in as a "{user_type}" user',
+    )
+    login_page.click_login()
+
     # Wait for redirect back to SPA
-    page.wait_for_timeout(3000)
+    try:
+        page.wait_for_url(f"*{SPA_HOST}*", timeout=15000)
+    except Exception:
+        pass
+    page.wait_for_timeout(2000)
 
 
 @then("I should be redirected back to the application")
@@ -470,10 +446,11 @@ def redirected_to_idp_login(page: Page, bdd_screenshot_helper):
 
 @when("I click the IDP login button")
 def click_idp_login_button(page: Page, bdd_screenshot_helper):
-    """Click the IDP login button to submit credentials."""
+    """Click the IDP login submit button (provider-agnostic)."""
     login_page = LoginPage(page)
+    # For Zitadel, the final submit was already handled in enter_valid_admin_credentials
+    # (two-step flow needs the password field filled before clicking submit here).
     login_page.click_login()
-    # Wait for navigation to start and take screenshot showing the consequence
     page.wait_for_timeout(1000)
     bdd_screenshot_helper.take_bdd_screenshot(
         login_page, "after-login-click", "And I click the IDP login button"

--- a/tests/e2e-browser/test_auth_flow_with_screenshots.py
+++ b/tests/e2e-browser/test_auth_flow_with_screenshots.py
@@ -60,7 +60,7 @@ class TestAuthFlowWithScreenshots:
             "direct",
         )
 
-        # Step 4: At Keycloak login page
+        # Step 4: At IDP login page (Keycloak single-step or Zitadel first step)
         login_page = LoginPage(page)
         login_page.wait_for_login_form(timeout=15000)
         login_page.assert_login_form_visible()
@@ -72,9 +72,16 @@ class TestAuthFlowWithScreenshots:
             "direct",
         )
 
-        # Step 5: Enter credentials
-        login_page.fill_username("admin@example.com")
-        login_page.fill_password("password")
+        # Step 5: Enter credentials (provider-aware)
+        if login_page._is_zitadel():
+            # Zitadel two-step: login-name first, then password on a second page
+            login_page.fill_username("admin@example.com")
+            login_page.click_login()  # Advance to password page
+            login_page.wait_for_selector(login_page.ZD_PASSWORD_INPUT, timeout=10000)
+            login_page.fill_password("Password1!")
+        else:
+            login_page.fill_username("admin@example.com")
+            login_page.fill_password("Password1!")
         login_page.take_screenshot(
             "credentials-entered",
             scenario_name,
@@ -83,12 +90,18 @@ class TestAuthFlowWithScreenshots:
             "direct",
         )
 
-        # Step 6: Submit login and wait for redirect back
+        # Step 6: Submit login and wait for redirect back to the SPA.
+        # Zitadel may take several seconds to process the password and complete
+        # the OIDC code exchange, so wait for the URL to return to the SPA first.
         login_page.click_login()
-        page.wait_for_timeout(1000)  # Wait for navigation
+        try:
+            page.wait_for_url(f"*{SPA_HOST}*", timeout=20000)
+        except Exception:
+            pass
+        page.wait_for_timeout(2000)  # allow oidc-client-ts to exchange the auth code
 
         # Step 7: Back at SPA and authenticated
-        page.wait_for_selector('text="Recent files"', timeout=10000)
+        page.wait_for_selector('text="Recent files"', timeout=15000)
         dashboard.assert_user_logged_in()
         dashboard.take_screenshot(
             "back-at-spa-authenticated",


### PR DESCRIPTION
Ref: #85, follows: #91

The main functional change of this PR is the decision to use Zitadel's `PRE_ACCESS_TOKEN_CREATION` which can be used for both human and machine users (other strategies I'd tried were only available in one of the two scenarios). This allows us to include the `collections` in the access token which can be retrieved by the API and included in STUF API calls to /api/me by the frontend.

The main diff change is the switch of the dummy dev password to something which is acceptable by both Zitadel and Keycloak (`password` -> `Password1!`).

Task doc: `tasks/0002-spa-collections-from-access-token.md`

## Generated Summary

- Standardize all test user passwords to `Password1!` to satisfy Zitadel's uppercase-required password policy (Keycloak accepts it too, eliminating provider-specific credential branches)
- Bind Zitadel action to `PRE_ACCESS_TOKEN_CREATION` (flow 2, trigger 5) so collections are injected into access tokens for **both** human and machine users — matching Keycloak's direct-claim shape exactly; no provider-specific fallbacks needed
- Remove `STUF_MACHINE_USER_COLLECTIONS` env-var fallback and `_extract_collections_from_roles()` from API middleware; service accounts now read `token_payload["collections"]` the same way user tokens do
- Replace `parseCollections()` in `useUser.ts` with a `GET /api/me` call on login — the API reads `collections` from the validated access token, making it the single authoritative source for both providers; no token-decoding or provider-specific logic remains in the SPA
- Add integration test coverage for Zitadel-shaped JWT payloads alongside the existing Keycloak fixtures
- Make SPA OIDC `scope` configurable at runtime via `OIDC_SCOPE` env var; `OIDC_LOAD_USER_INFO` defaults to `false` for both providers (userinfo endpoint no longer needed for collection delivery)
- Fix Keycloak realm to include `collections` claim in the userinfo endpoint response

## Test plan

- [x] Fast tests (`make test`) pass unchanged
- [x] Keycloak E2E (`make test-e2e`) passes — all credential and SPA config changes are backward-compatible