### PR TITLE
e2e: Zitadel browser tests and CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,15 +99,15 @@ jobs:
           echo "=== Docker containers ==="
           docker ps -a
           echo "=== Docker compose services ==="
-          docker compose -f tests/e2e-browser/docker-compose.e2e-browser.yml ps
+          docker compose -f tests/e2e-browser/docker-compose.e2e-browser.yml --profile keycloak ps
           echo "=== Keycloak logs ==="
-          docker compose -f tests/e2e-browser/docker-compose.e2e-browser.yml logs keycloak-e2e || echo "No Keycloak logs available"
+          docker compose -f tests/e2e-browser/docker-compose.e2e-browser.yml --profile keycloak logs keycloak-e2e || echo "No Keycloak logs available"
           echo "=== API logs ==="
-          docker compose -f tests/e2e-browser/docker-compose.e2e-browser.yml logs api-e2e || echo "No API logs available"
+          docker compose -f tests/e2e-browser/docker-compose.e2e-browser.yml --profile keycloak logs api-e2e || echo "No API logs available"
           echo "=== MinIO logs ==="
-          docker compose -f tests/e2e-browser/docker-compose.e2e-browser.yml logs minio-e2e || echo "No MinIO logs available"
+          docker compose -f tests/e2e-browser/docker-compose.e2e-browser.yml --profile keycloak logs minio-e2e || echo "No MinIO logs available"
           echo "=== SPA logs ==="
-          docker compose -f tests/e2e-browser/docker-compose.e2e-browser.yml logs spa-e2e || echo "No SPA logs available"
+          docker compose -f tests/e2e-browser/docker-compose.e2e-browser.yml --profile keycloak logs spa-e2e || echo "No SPA logs available"
 
       - name: Upload coverage reports
         uses: actions/upload-artifact@v4
@@ -125,10 +125,88 @@ jobs:
           path: tests/e2e-browser/reports/
           retention-days: 3
 
+  e2e-tests-zitadel:
+    name: E2E Tests (Zitadel)
+    runs-on: ubuntu-latest
+    needs: fast-tests
+    if: success()
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+          cache-dependency-path: spa/package-lock.json
+
+      - name: Install Python dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements-dev.txt
+          pip install -r api/requirements.txt
+
+      - name: Install SPA dependencies
+        working-directory: spa
+        run: npm ci
+
+      - name: Update system packages
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y wget gnupg
+
+      - name: Install browser E2E test dependencies
+        run: |
+          pip install -r tests/e2e-browser/requirements.txt
+          playwright install --with-deps chromium
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Prepare bootstrap directory
+        run: mkdir -p tests/e2e-browser/.zitadel-bootstrap
+
+      - name: Run E2E tests against Zitadel
+        run: make test-e2e-zitadel
+
+      - name: Show Docker containers and logs on failure
+        if: failure()
+        run: |
+          echo "=== Docker containers ==="
+          docker ps -a
+          echo "=== Docker compose services ==="
+          docker compose -f tests/e2e-browser/docker-compose.e2e-browser.yml --profile zitadel ps
+          echo "=== Zitadel logs ==="
+          docker compose -f tests/e2e-browser/docker-compose.e2e-browser.yml --profile zitadel logs zitadel-e2e || echo "No Zitadel logs available"
+          echo "=== Zitadel init logs ==="
+          docker compose -f tests/e2e-browser/docker-compose.e2e-browser.yml --profile zitadel logs zitadel-init-e2e || echo "No Zitadel init logs available"
+          echo "=== Zitadel login logs ==="
+          docker compose -f tests/e2e-browser/docker-compose.e2e-browser.yml --profile zitadel logs zitadel-login-e2e || echo "No Zitadel login logs available"
+          echo "=== API logs ==="
+          docker compose -f tests/e2e-browser/docker-compose.e2e-browser.yml --profile zitadel logs api-e2e || echo "No API logs available"
+          echo "=== SPA logs ==="
+          docker compose -f tests/e2e-browser/docker-compose.e2e-browser.yml --profile zitadel logs spa-e2e || echo "No SPA logs available"
+          echo "=== Bootstrap generated.env ==="
+          cat tests/e2e-browser/.zitadel-bootstrap/generated.env || echo "No generated.env"
+
+      - name: Upload test reports
+        uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: test-reports-zitadel
+          path: tests/e2e-browser/reports/
+          retention-days: 3
+
   publish-containers:
     name: Publish Container Images
     runs-on: ubuntu-latest
-    needs: e2e-tests
+    needs: [e2e-tests, e2e-tests-zitadel]
     if: success() && github.ref == 'refs/heads/master'
     permissions:
       contents: read

--- a/Makefile
+++ b/Makefile
@@ -164,8 +164,7 @@ test-e2e-zitadel:
 		export OIDC_SPA_CLIENT_ID="$${ZITADEL_SPA_CLIENT_ID}"; \
 		export OIDC_AUTHORITY=http://zitadel-e2e:8080; \
 		export OIDC_CLIENT_ID="$${ZITADEL_SPA_CLIENT_ID}"; \
-		export OIDC_SCOPE="openid profile email stuf:access urn:zitadel:iam:user:metadata"; \
-		export OIDC_LOAD_USER_INFO="true"; \
+		export OIDC_SCOPE="openid profile email stuf:access"; \
 		export IDP_URL=http://zitadel-e2e:8080; \
 		export OIDC_SERVICE_ACCOUNT_CLIENT_ID="$${ZITADEL_BACKUP_SERVICE_CLIENT_ID}"; \
 		export OIDC_SERVICE_ACCOUNT_CLIENT_SECRET="$${ZITADEL_BACKUP_SERVICE_CLIENT_SECRET}"; \

--- a/tasks/0001-support-zitadel-as-oidc-provider.md
+++ b/tasks/0001-support-zitadel-as-oidc-provider.md
@@ -530,9 +530,11 @@ These need decisions or upstream investigation before implementation:
       `accessTokenRoleAssertion: True` on the SPA app.
     - `ctx.v1.user` is populated for both human and machine users; `sub`
       maps to the right user id in both cases.
-    - `ctx.v1.user.getMetadata()` returns the user's metadata array (works
-      for human and machine users alike). Each entry's `value` arrives as a
-      JSON-decoded object when the stored bytes are valid JSON, so
+    - `ctx.v1.user.getMetadata()` returns a **wrapper object**
+      `{count, sequence, timestamp, metadata: [...]}`, not the array
+      directly. Access `result.metadata` to get the `[{key, value}]` array
+      (works for human and machine users alike). Each entry's `value` arrives
+      as a JSON-decoded object when the stored bytes are valid JSON, so
       `api.v1.claims.setClaim("collections", entry.value)` is sufficient —
       no `atob`/JSON.parse dance, and `atob` is in fact not defined in
       Zitadel's goja runtime.

--- a/tests/e2e-browser/docker-compose.e2e-browser.yml
+++ b/tests/e2e-browser/docker-compose.e2e-browser.yml
@@ -5,14 +5,22 @@
 # Port mapping to avoid conflicts with main docker-compose:
 # Main:    Keycloak:8080, MinIO:9000/9001, API:8000, SPA:3000
 # E2E:     Keycloak:8180, MinIO:9100/9101, API:8100, SPA:3100
+#          Zitadel:8280,  Zitadel-login:8290
+#
+# IDP profile selection:
+#   Keycloak (default): docker compose --profile keycloak --profile testing up
+#   Zitadel:            docker compose --profile zitadel --profile testing up
+#                       (requires OIDC_ISSUER_URL etc. set from .zitadel-bootstrap/generated.env)
 
 networks:
   stuf-e2e-test-net:
     driver: bridge
 
 services:
-  # Keycloak - Identity Provider
+  # ── Keycloak identity provider ────────────────────────────────────────────
   keycloak-e2e:
+    profiles:
+      - keycloak
     build:
       context: ../../docker/keycloak
       dockerfile: Dockerfile
@@ -23,7 +31,7 @@ services:
     ports:
       - "8180:8080" # Different port to avoid conflict
       - "9191:9000" # Management port (different from main 9990)
-    command: start-dev --import-realm
+    command: start-dev --import-realm --health-enabled=true
     volumes:
       - ../../docker/keycloak/data:/opt/keycloak/data
     networks:
@@ -35,7 +43,164 @@ services:
       retries: 30
       start_period: 60s
 
-  # MinIO - Object Storage
+  # ── Zitadel identity provider stack ──────────────────────────────────────
+  # All Zitadel e2e services run on the bridge network so that the Playwright
+  # browser inside the test-runner container can reach them by hostname.
+  # ZITADEL_EXTERNALDOMAIN=zitadel-e2e makes Zitadel accept requests on that
+  # hostname.  An Nginx reverse proxy (zitadel-e2e) sits in front, routing
+  # /ui/v2/login/* to the login UI and everything else to the Zitadel backend.
+  # This means the browser always uses zitadel-e2e:8080 as the OIDC authority,
+  # which matches EXTERNALDOMAIN and avoids "public domain not trusted" errors
+  # from the login UI making server-side calls to Zitadel.
+  zitadel-postgres-e2e:
+    image: postgres:17
+    profiles:
+      - zitadel
+    environment:
+      POSTGRES_USER: zitadel
+      POSTGRES_PASSWORD: zitadel
+      POSTGRES_DB: zitadel
+    networks:
+      - stuf-e2e-test-net
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U zitadel -d zitadel"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
+
+  zitadel-bootstrap-init-e2e:
+    image: busybox:1.37
+    profiles:
+      - zitadel
+    command: ["chmod", "777", "/bootstrap"]
+    volumes:
+      - ./.zitadel-bootstrap:/bootstrap
+    networks:
+      - stuf-e2e-test-net
+    restart: "no"
+
+  zitadel-backend-e2e:
+    image: ghcr.io/zitadel/zitadel:v4.14.0
+    profiles:
+      - zitadel
+    command: start-from-init --masterkey "MasterkeyNeedsToHave32Characters" --tlsMode disabled
+    environment:
+      ZITADEL_DATABASE_POSTGRES_HOST: zitadel-postgres-e2e
+      ZITADEL_DATABASE_POSTGRES_PORT: 5432
+      ZITADEL_DATABASE_POSTGRES_DATABASE: zitadel
+      ZITADEL_DATABASE_POSTGRES_USER_USERNAME: zitadel
+      ZITADEL_DATABASE_POSTGRES_USER_PASSWORD: zitadel
+      ZITADEL_DATABASE_POSTGRES_USER_SSL_MODE: disable
+      ZITADEL_DATABASE_POSTGRES_ADMIN_USERNAME: zitadel
+      ZITADEL_DATABASE_POSTGRES_ADMIN_PASSWORD: zitadel
+      ZITADEL_DATABASE_POSTGRES_ADMIN_SSL_MODE: disable
+      ZITADEL_TLS_ENABLED: "false"
+      ZITADEL_EXTERNALSECURE: "false"
+      ZITADEL_EXTERNALPORT: 8080
+      # External domain matches the Nginx proxy hostname so all containers
+      # (including the browser in the test-runner) use http://zitadel-e2e:8080.
+      ZITADEL_EXTERNALDOMAIN: zitadel-e2e
+      # LOGINV2_BASEURI routes the browser through the Nginx proxy so the
+      # login UI's server-side API calls carry the zitadel-e2e origin.
+      ZITADEL_DEFAULTINSTANCE_FEATURES_LOGINV2_BASEURI: http://zitadel-e2e:8080/ui/v2/login
+      ZITADEL_FIRSTINSTANCE_ORG_NAME: STUF
+      ZITADEL_FIRSTINSTANCE_ORG_HUMAN_USERNAME: admin
+      ZITADEL_FIRSTINSTANCE_ORG_HUMAN_PASSWORD: Password1!
+      ZITADEL_FIRSTINSTANCE_ORG_HUMAN_PASSWORDCHANGEREQUIRED: "false"
+      ZITADEL_FIRSTINSTANCE_ORG_HUMAN_EMAIL_ADDRESS: admin@example.com
+      ZITADEL_FIRSTINSTANCE_ORG_HUMAN_EMAIL_VERIFIED: "true"
+      ZITADEL_FIRSTINSTANCE_ORG_HUMAN_FIRSTNAME: Admin
+      ZITADEL_FIRSTINSTANCE_ORG_HUMAN_LASTNAME: User
+      ZITADEL_FIRSTINSTANCE_ORG_MACHINE_MACHINE_USERNAME: zitadel-admin-sa
+      ZITADEL_FIRSTINSTANCE_ORG_MACHINE_MACHINE_NAME: Zitadel Admin SA
+      ZITADEL_FIRSTINSTANCE_ORG_MACHINE_MACHINEKEY_TYPE: 1
+      ZITADEL_FIRSTINSTANCE_MACHINEKEYPATH: /bootstrap/zitadel-admin-sa.json
+    volumes:
+      - ./.zitadel-bootstrap:/bootstrap
+    networks:
+      - stuf-e2e-test-net
+    depends_on:
+      zitadel-postgres-e2e:
+        condition: service_healthy
+      zitadel-bootstrap-init-e2e:
+        condition: service_completed_successfully
+    healthcheck:
+      test: ["CMD", "/app/zitadel", "ready"]
+      interval: 10s
+      timeout: 3s
+      retries: 10
+      start_period: 60s
+
+  # Nginx reverse proxy: presents a single zitadel-e2e:8080 hostname to all
+  # clients.  Routes /ui/v2/login/* to the login UI and everything else to the
+  # Zitadel backend.  Because the browser always hits zitadel-e2e:8080, the
+  # login UI's server-side API calls carry Host: zitadel-e2e, matching
+  # EXTERNALDOMAIN and avoiding "public domain not trusted" errors.
+  zitadel-e2e:
+    image: nginx:alpine
+    profiles:
+      - zitadel
+    volumes:
+      - ./nginx/default.conf:/etc/nginx/nginx.conf:ro
+    ports:
+      - "8280:8080"
+    networks:
+      - stuf-e2e-test-net
+    depends_on:
+      zitadel-backend-e2e:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "sh", "-c", "wget -qO- http://127.0.0.1:8080/healthz"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+      start_period: 5s
+
+  zitadel-init-e2e:
+    build:
+      context: ../../docker/zitadel-init
+      dockerfile: Dockerfile
+    profiles:
+      - zitadel
+    # Call the Nginx proxy so the Host header is zitadel-e2e:8080, matching
+    # EXTERNALDOMAIN=zitadel-e2e (direct calls to zitadel-backend-e2e would
+    # have the wrong Host and fail instance routing).
+    environment:
+      ZITADEL_DOMAIN: http://zitadel-e2e:8080
+      MACHINE_KEY_PATH: /bootstrap/zitadel-admin-sa.json
+      BOOTSTRAP_DIR: /bootstrap
+      FIXTURE_PATH: /fixtures/dev/instance.yaml
+    volumes:
+      - ./.zitadel-bootstrap:/bootstrap
+      - ../../docker/zitadel-init:/fixtures:ro
+    networks:
+      - stuf-e2e-test-net
+    depends_on:
+      zitadel-e2e:
+        condition: service_healthy
+    restart: "no"
+
+  zitadel-login-e2e:
+    image: ghcr.io/zitadel/zitadel-login:v4.14.0
+    profiles:
+      - zitadel
+    entrypoint: ["/bin/sh", "-c", "export ZITADEL_SERVICE_USER_TOKEN=$(cat /bootstrap/login-token) && exec /app/entrypoint.sh node apps/login/server.js"]
+    environment:
+      # Use the Nginx proxy URL so that when the login UI makes server-side
+      # API calls the Host header is zitadel-e2e:8080, matching EXTERNALDOMAIN.
+      ZITADEL_API_URL: http://zitadel-e2e:8080
+      PORT: 8090
+    volumes:
+      - ./.zitadel-bootstrap:/bootstrap:ro
+    ports:
+      - "8290:8090"
+    networks:
+      - stuf-e2e-test-net
+    depends_on:
+      zitadel-init-e2e:
+        condition: service_completed_successfully
+
+  # ── MinIO - Object Storage (shared by both IDP profiles) ─────────────────
   minio-e2e:
     image: minio/minio:latest
     environment:
@@ -56,7 +221,7 @@ services:
       retries: 15
       start_period: 10s
 
-  # FastAPI Backend
+  # ── FastAPI Backend ───────────────────────────────────────────────────────
   api-e2e:
     build:
       context: ../../api
@@ -64,9 +229,17 @@ services:
     ports:
       - "8100:8000" # Different port
     environment:
-      # OIDC configuration (internal network; issuer and fetch URL are the same in e2e)
-      - OIDC_ISSUER_URL=http://keycloak-e2e:8080/realms/stuf
-      - OIDC_VALID_AUDIENCES=stuf-api,stuf-spa
+      # OIDC configuration — defaults to Keycloak; override for Zitadel by
+      # setting OIDC_ISSUER_URL, OIDC_BASE_URL, OIDC_VALID_AUDIENCES, and
+      # OIDC_SPA_CLIENT_ID in the shell before running docker compose.
+      # For Zitadel, source .zitadel-bootstrap/generated.env after init completes.
+      - OIDC_ISSUER_URL=${OIDC_ISSUER_URL:-http://keycloak-e2e:8080/realms/stuf}
+      - OIDC_BASE_URL=${OIDC_BASE_URL:-${OIDC_ISSUER_URL:-http://keycloak-e2e:8080/realms/stuf}}
+      - OIDC_VALID_AUDIENCES=${OIDC_VALID_AUDIENCES:-stuf-api,stuf-spa}
+      - OIDC_SPA_CLIENT_ID=${OIDC_SPA_CLIENT_ID:-stuf-spa}
+      # Machine user collection permissions written by zitadel-init (JSON map).
+      # Empty string when running against Keycloak (not needed; collections are JWT claims).
+      - STUF_MACHINE_USER_COLLECTIONS=${STUF_MACHINE_USER_COLLECTIONS:-}
 
       # MinIO configuration (internal network)
       - MINIO_ENDPOINT=minio-e2e:9000
@@ -78,8 +251,6 @@ services:
       - CORS_ORIGINS=http://spa-e2e:3000
     depends_on:
       minio-e2e:
-        condition: service_healthy
-      keycloak-e2e:
         condition: service_healthy
     networks:
       - stuf-e2e-test-net
@@ -96,7 +267,7 @@ services:
       retries: 15
       start_period: 30s
 
-  # React SPA Frontend
+  # ── React SPA Frontend ────────────────────────────────────────────────────
   spa-e2e:
     build:
       context: ../../spa
@@ -109,10 +280,12 @@ services:
       - API_URL=http://api-e2e:8000
 
       # OIDC authority passed directly so docker-entrypoint.sh needs no realm
-      # path assembly. For Keycloak the value is keycloakUrl/realms/realm;
-      # for Zitadel it is just the issuer URL (no realm segment).
-      - OIDC_AUTHORITY=http://keycloak-e2e:8080/realms/stuf
-      - OIDC_CLIENT_ID=stuf-spa
+      # path assembly. Defaults to Keycloak; override for Zitadel by setting
+      # OIDC_AUTHORITY=http://zitadel-e2e:8080 and OIDC_CLIENT_ID=<generated>.
+      - OIDC_AUTHORITY=${OIDC_AUTHORITY:-http://keycloak-e2e:8080/realms/stuf}
+      - OIDC_CLIENT_ID=${OIDC_CLIENT_ID:-stuf-spa}
+      - OIDC_SCOPE=${OIDC_SCOPE:-openid profile email stuf:access}
+      - OIDC_LOAD_USER_INFO=${OIDC_LOAD_USER_INFO:-false}
     depends_on:
       - api-e2e
     networks:
@@ -130,7 +303,7 @@ services:
       retries: 15
       start_period: 15s
 
-  # Test runner - runs Playwright tests inside Docker network
+  # ── Test runner ────────────────────────────────────────────────────────────
   test-runner:
     build:
       context: ../.. # Build from project root to access both tests/e2e-browser and api
@@ -139,22 +312,29 @@ services:
       # Use internal Docker network URLs
       - SPA_URL=http://spa-e2e:3000
       - API_URL=http://api-e2e:8000
-      - IDP_URL=http://keycloak-e2e:8080
+      - IDP_URL=${IDP_URL:-http://keycloak-e2e:8080}
       - MINIO_URL=http://minio-e2e:9000
-      # OIDC configuration (provider-agnostic)
-      - OIDC_ISSUER_URL=http://keycloak-e2e:8080/realms/stuf
-      - OIDC_VALID_AUDIENCES=stuf-api,stuf-spa
+      # OIDC configuration (provider-agnostic; mirror of api-e2e vars above)
+      - OIDC_ISSUER_URL=${OIDC_ISSUER_URL:-http://keycloak-e2e:8080/realms/stuf}
+      - OIDC_VALID_AUDIENCES=${OIDC_VALID_AUDIENCES:-stuf-api,stuf-spa}
+      - OIDC_SPA_CLIENT_ID=${OIDC_SPA_CLIENT_ID:-stuf-spa}
+      # Service-account credentials (Keycloak defaults; override for Zitadel)
+      - OIDC_SERVICE_ACCOUNT_CLIENT_ID=${OIDC_SERVICE_ACCOUNT_CLIENT_ID:-backup-service}
+      - OIDC_SERVICE_ACCOUNT_CLIENT_SECRET=${OIDC_SERVICE_ACCOUNT_CLIENT_SECRET:-backup-service-secret}
+      - OIDC_SERVICE_ACCOUNT_SCOPES=${OIDC_SERVICE_ACCOUNT_SCOPES:-stuf:access}
       # MinIO configuration for API E2E tests
       - MINIO_ENDPOINT=minio-e2e:9000
       - MINIO_ROOT_USER=minioadmin
       - MINIO_ROOT_PASSWORD=minioadmin
       - MINIO_BUCKET_NAME=stuf-uploads-e2e
+      # Machine user collection permissions (base64 JSON) written by zitadel-init.
+      # The test-runner imports the STUF API directly (TestClient) so needs this
+      # env var for the middleware's fallback collection lookup.
+      - STUF_MACHINE_USER_COLLECTIONS=${STUF_MACHINE_USER_COLLECTIONS:-}
     depends_on:
       spa-e2e:
         condition: service_healthy
       api-e2e:
-        condition: service_healthy
-      keycloak-e2e:
         condition: service_healthy
       minio-e2e:
         condition: service_healthy
@@ -165,6 +345,8 @@ services:
       - .:/app
       # Mount the entire API directory for imports and tests
       - ../../api:/app/api
+      # Zitadel bootstrap dir (present when running --profile zitadel; read-only)
+      - ./.zitadel-bootstrap:/bootstrap:ro
     profiles:
       - testing
 

--- a/tests/e2e-browser/docker-compose.e2e-browser.yml
+++ b/tests/e2e-browser/docker-compose.e2e-browser.yml
@@ -237,10 +237,6 @@ services:
       - OIDC_BASE_URL=${OIDC_BASE_URL:-${OIDC_ISSUER_URL:-http://keycloak-e2e:8080/realms/stuf}}
       - OIDC_VALID_AUDIENCES=${OIDC_VALID_AUDIENCES:-stuf-api,stuf-spa}
       - OIDC_SPA_CLIENT_ID=${OIDC_SPA_CLIENT_ID:-stuf-spa}
-      # Machine user collection permissions written by zitadel-init (JSON map).
-      # Empty string when running against Keycloak (not needed; collections are JWT claims).
-      - STUF_MACHINE_USER_COLLECTIONS=${STUF_MACHINE_USER_COLLECTIONS:-}
-
       # MinIO configuration (internal network)
       - MINIO_ENDPOINT=minio-e2e:9000
       - MINIO_ROOT_USER=minioadmin
@@ -327,10 +323,6 @@ services:
       - MINIO_ROOT_USER=minioadmin
       - MINIO_ROOT_PASSWORD=minioadmin
       - MINIO_BUCKET_NAME=stuf-uploads-e2e
-      # Machine user collection permissions (base64 JSON) written by zitadel-init.
-      # The test-runner imports the STUF API directly (TestClient) so needs this
-      # env var for the middleware's fallback collection lookup.
-      - STUF_MACHINE_USER_COLLECTIONS=${STUF_MACHINE_USER_COLLECTIONS:-}
     depends_on:
       spa-e2e:
         condition: service_healthy


### PR DESCRIPTION
Ref: #85, follows: #97

Main change here is adding the zitadel services to the e2e compose file, and there are a few:
 - zitadel-postgres-e2e — Zitadel's database. Unlike Keycloak which embeds H2, Zitadel requires an external Postgres.
                                                                                               
- zitadel-bootstrap-init-e2e — A one-shot busybox container that runs chmod 777 /bootstrap on the shared volume before anything else starts. Three containers with different internal users   (Zitadel, the init script, the login UI) all need read/write access to that directory, and there's no clean way to pre-set permissions without a common user — so world-writable is the pragmatic dev-only compromise.
- zitadel-backend-e2e — The actual Zitadel server. On first start it initialises the database schema, creates the admin org/user, and writes a machine-key JSON file to the bootstrap volume that zitadel-init will later use to authenticate against the API.
- zitadel-init-e2e — A one-shot Python provisioning script that calls the Zitadel API (via the proxy, so Host: zitadel-e2e is correct) to create the STUF project, OIDC apps, action that injects the collections claim, and all the test users. Writes the generated client IDs and secrets to generated.env for the Makefile to pick up.                                            
- zitadel-login-e2e — Zitadel's separate Login v2 UI (a Next.js app). Zitadel's auth logic lives in the backend but the login page is this standalone service. It makes server-side API calls back to Zitadel, which is why it needs to go through the proxy — direct calls to zitadel-backend-e2e would have the wrong hostname in the Host header and fail.


## Summary

- Add the full Zitadel service stack to `docker-compose.e2e-browser.yml` under `--profile zitadel` (Postgres, Zitadel backend, login UI, init container, Nginx proxy from #97)
- Update browser E2E test code (`authentication_steps.py`, `test_auth_flow_with_screenshots.py`, `conftest.py`) to handle both Keycloak and Zitadel login flows generically using `IDP_URL`
- Remove `STUF_MACHINE_USER_COLLECTIONS` env var from both `api-e2e` and `test-runner` services — collections now arrive as a JWT claim via the trigger-5 action (landed in #93), so the fallback env var is no longer needed
- Drop `OIDC_LOAD_USER_INFO` and `urn:zitadel:iam:user:metadata` from the `test-e2e-zitadel` Makefile target — the SPA now fetches collections from `/api/me` (landed in #93) so the userinfo endpoint is no longer part of the flow
- Add `test-e2e-zitadel` CI job that runs `make test-e2e-zitadel` with failure diagnostics (container logs on failure)

## Test plan

- [x] Keycloak E2E CI job still passes
- [x] New Zitadel E2E CI job passes (`make test-e2e-zitadel`)