### PR TITLE
dev: add spa-dev-zitadel for local manual testing with Zitadel IdP

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,10 @@ tests/e2e-browser/reports/
 tests/e2e-browser/auth-storage-state.json
 tests/.venv/
 
+# Zitadel bootstrap (generated at runtime; keep directory, ignore contents)
+.zitadel-bootstrap/*
+!.zitadel-bootstrap/.gitkeep
+
 # Zitadel e2e bootstrap (generated at runtime; keep directory, ignore contents)
 tests/e2e-browser/.zitadel-bootstrap/*
 !tests/e2e-browser/.zitadel-bootstrap/.gitkeep

--- a/Makefile
+++ b/Makefile
@@ -52,10 +52,11 @@ help:
 	@echo "  test-cov          Run tests with coverage report"
 	@echo ""
 	@echo "SPA Development:"
-	@echo "  spa-dev       Start SPA in development mode with hot reloading"
-	@echo "  spa-prod      Start SPA in production mode"
-	@echo "  spa-build     Build SPA for production"
-	@echo "  spa-stop      Stop SPA services"
+	@echo "  spa-dev           Start SPA in development mode (Keycloak IdP)"
+	@echo "  spa-dev-zitadel   Start SPA in development mode (Zitadel IdP)"
+	@echo "  spa-prod          Start SPA in production mode"
+	@echo "  spa-build         Build SPA for production"
+	@echo "  spa-stop          Stop SPA services"
 	@echo ""
 	@echo "Container Publishing:"
 	@echo "  build-containers    Build all containers for publishing"
@@ -115,6 +116,8 @@ clean:
 	@echo "Cleaning Keycloak local state..."
 	@rm -rf docker/keycloak/data/h2
 	@rm -rf docker/keycloak/data/transaction-logs
+	@echo "Cleaning Zitadel bootstrap..."
+	@rm -f .zitadel-bootstrap/*.env .zitadel-bootstrap/*.json
 	@echo "Cleaning Zitadel e2e bootstrap..."
 	@rm -f tests/e2e-browser/.zitadel-bootstrap/*.env tests/e2e-browser/.zitadel-bootstrap/*.json
 	@echo "Cleaning SPA generated config..."
@@ -191,14 +194,43 @@ test-cov: $(VENV_DIR)/dev-requirements.stamp
 	@$(PYTEST) -m "not e2e" --cov=api --cov-report=html --cov-report=term-missing
 
 # SPA development and production targets
-.PHONY: spa-dev spa-prod spa-build spa-stop
+.PHONY: spa-dev spa-dev-zitadel spa-prod spa-build spa-stop
 
-# Start SPA in development mode with hot reloading
+# Start SPA in development mode with Keycloak IdP and hot reloading
 spa-dev:
-	@echo "Starting SPA in development mode with hot reloading..."
-	@echo "This includes full environment (API, IDP, MinIO) + fast SPA reloading"
+	@echo "Starting SPA in development mode (Keycloak IdP) with hot reloading..."
+	@echo "This includes full environment (API, Keycloak, MinIO) + fast SPA reloading"
 	@echo "Access at: http://localhost:3000"
-	@docker compose -f docker-compose.yml -f docker-compose.dev.yml up --build
+	@docker compose -f docker-compose.yml -f docker-compose.dev.yml --profile keycloak up --build
+
+# Start SPA in development mode with Zitadel IdP and hot reloading
+# Mirrors the test-e2e-zitadel flow: starts the Zitadel stack, runs provisioning,
+# reads the generated OIDC credentials, then starts api + spa with those vars.
+spa-dev-zitadel:
+	@echo "Starting SPA in development mode (Zitadel IdP) with hot reloading..."
+	@mkdir -p .zitadel-bootstrap
+	@echo "Building services..."
+	@docker compose -f docker-compose.yml -f docker-compose.dev.yml --profile zitadel build zitadel-init api spa
+	@echo "Starting Zitadel stack..."
+	@docker compose -f docker-compose.yml --profile zitadel up -d --wait zitadel-postgres zitadel-bootstrap-init zitadel
+	@echo "Running Zitadel provisioning..."
+	@docker compose -f docker-compose.yml --profile zitadel up --no-deps zitadel-init
+	@echo "Starting Zitadel login UI and MinIO..."
+	@docker compose -f docker-compose.yml --profile zitadel up -d --no-deps --wait zitadel-login minio
+	@echo "Reading generated Zitadel credentials..."
+	@test -f .zitadel-bootstrap/generated.env || (echo "ERROR: .zitadel-bootstrap/generated.env not found"; exit 1)
+	@echo "Starting API and SPA with Zitadel configuration..."
+	@( \
+		set -a; . .zitadel-bootstrap/generated.env; set +a; \
+		export OIDC_ISSUER_URL=http://localhost:8080; \
+		export OIDC_BASE_URL=http://zitadel:8080; \
+		export OIDC_VALID_AUDIENCES="$${ZITADEL_SPA_CLIENT_ID},$${ZITADEL_API_APP_CLIENT_ID},$${ZITADEL_STUF_PROJECT_ID}"; \
+		export OIDC_SPA_CLIENT_ID="$${ZITADEL_SPA_CLIENT_ID}"; \
+		export OIDC_AUTHORITY=http://localhost:8080; \
+		export OIDC_CLIENT_ID="$${ZITADEL_SPA_CLIENT_ID}"; \
+		export OIDC_SCOPE="openid profile email stuf:access"; \
+		docker compose -f docker-compose.yml -f docker-compose.dev.yml --profile zitadel up api spa \
+	)
 
 # Start SPA in production mode
 spa-prod:
@@ -211,13 +243,15 @@ spa-build:
 	@echo "Building SPA for production..."
 	@docker compose build --target production spa
 
-# Stop SPA services
+# Stop SPA services (all profiles)
 spa-stop:
 	@echo "Stopping SPA services..."
-	@docker compose down
+	@docker compose --profile keycloak --profile zitadel down
 	@echo "Cleaning Keycloak local state..."
 	@rm -rf docker/keycloak/data/h2
 	@rm -rf docker/keycloak/data/transaction-logs
+	@echo "Cleaning Zitadel bootstrap..."
+	@rm -f .zitadel-bootstrap/*.env .zitadel-bootstrap/*.json
 	@echo "Cleaning Zitadel e2e bootstrap..."
 	@rm -f tests/e2e-browser/.zitadel-bootstrap/*.env tests/e2e-browser/.zitadel-bootstrap/*.json
 	@echo "Cleaning generated config..."

--- a/Makefile
+++ b/Makefile
@@ -212,11 +212,11 @@ spa-dev-zitadel:
 	@echo "Building services..."
 	@docker compose -f docker-compose.yml -f docker-compose.dev.yml --profile zitadel build zitadel-init api spa
 	@echo "Starting Zitadel stack..."
-	@docker compose -f docker-compose.yml --profile zitadel up -d --wait zitadel-postgres zitadel-bootstrap-init zitadel
+	@docker compose -f docker-compose.yml -f docker-compose.dev.yml --profile zitadel up -d --wait --remove-orphans zitadel-postgres zitadel-bootstrap-init zitadel
 	@echo "Running Zitadel provisioning..."
-	@docker compose -f docker-compose.yml --profile zitadel up --no-deps zitadel-init
+	@docker compose -f docker-compose.yml -f docker-compose.dev.yml --profile zitadel up --no-deps zitadel-init
 	@echo "Starting Zitadel login UI and MinIO..."
-	@docker compose -f docker-compose.yml --profile zitadel up -d --no-deps --wait zitadel-login minio
+	@docker compose -f docker-compose.yml -f docker-compose.dev.yml --profile zitadel up -d --no-deps --wait zitadel-login minio
 	@echo "Reading generated Zitadel credentials..."
 	@test -f .zitadel-bootstrap/generated.env || (echo "ERROR: .zitadel-bootstrap/generated.env not found"; exit 1)
 	@echo "Starting API and SPA with Zitadel configuration..."

--- a/Makefile
+++ b/Makefile
@@ -208,7 +208,10 @@ spa-dev:
 # reads the generated OIDC credentials, then starts api + spa with those vars.
 spa-dev-zitadel:
 	@echo "Starting SPA in development mode (Zitadel IdP) with hot reloading..."
+	@echo "Cleaning up any previous run..."
+	@docker compose -f docker-compose.yml -f docker-compose.dev.yml --profile keycloak --profile zitadel down --remove-orphans 2>/dev/null || true
 	@mkdir -p .zitadel-bootstrap
+	@rm -f .zitadel-bootstrap/*.env .zitadel-bootstrap/*.json
 	@echo "Building services..."
 	@docker compose -f docker-compose.yml -f docker-compose.dev.yml --profile zitadel build zitadel-init api spa
 	@echo "Starting Zitadel stack..."
@@ -224,6 +227,7 @@ spa-dev-zitadel:
 		set -a; . .zitadel-bootstrap/generated.env; set +a; \
 		export OIDC_ISSUER_URL=http://localhost:8080; \
 		export OIDC_BASE_URL=http://zitadel:8080; \
+		export OIDC_ISSUER_HOST=localhost:8080; \
 		export OIDC_VALID_AUDIENCES="$${ZITADEL_SPA_CLIENT_ID},$${ZITADEL_API_APP_CLIENT_ID},$${ZITADEL_STUF_PROJECT_ID}"; \
 		export OIDC_SPA_CLIENT_ID="$${ZITADEL_SPA_CLIENT_ID}"; \
 		export OIDC_AUTHORITY=http://localhost:8080; \

--- a/api/auth/middleware.py
+++ b/api/auth/middleware.py
@@ -3,7 +3,6 @@ import logging
 import os
 import time
 from typing import Optional, Union
-from urllib.parse import urlparse
 
 import requests
 from domain.models import ServiceAccount, User
@@ -43,14 +42,12 @@ _discovery_doc: dict = {}
 _jwks_cache: dict = {"keys": [], "fetched_at": 0.0}
 _JWKS_TTL = 300  # seconds
 
-# When the issuer URL (as seen by clients/tokens) differs from the base URL
-# used for internal fetching, some providers (e.g. Zitadel) validate the Host
-# header against their configured external domain and return 404 for requests
-# that arrive on an internal hostname.  We override Host to the issuer's
-# netloc and rebase any URLs in discovery responses back through _OIDC_BASE_URL.
-_issuer_host: str = (
-    urlparse(OIDC_ISSUER_URL).netloc if _OIDC_BASE_URL != OIDC_ISSUER_URL else ""
-)
+# OIDC_ISSUER_HOST: when set, requests to the discovery document and JWKS
+# endpoint are sent with this value as the Host header. Required when
+# OIDC_BASE_URL is a Docker-internal hostname and the provider validates the
+# Host header against its configured external domain (e.g. Zitadel in a
+# split-horizon dev setup). Leave unset in standard deployments.
+_issuer_host: str = os.environ.get("OIDC_ISSUER_HOST", "")
 
 
 def _rebase_url(url: str) -> str:

--- a/api/auth/middleware.py
+++ b/api/auth/middleware.py
@@ -3,6 +3,7 @@ import logging
 import os
 import time
 from typing import Optional, Union
+from urllib.parse import urlparse
 
 import requests
 from domain.models import ServiceAccount, User
@@ -42,6 +43,31 @@ _discovery_doc: dict = {}
 _jwks_cache: dict = {"keys": [], "fetched_at": 0.0}
 _JWKS_TTL = 300  # seconds
 
+# When the issuer URL (as seen by clients/tokens) differs from the base URL
+# used for internal fetching, some providers (e.g. Zitadel) validate the Host
+# header against their configured external domain and return 404 for requests
+# that arrive on an internal hostname.  We override Host to the issuer's
+# netloc and rebase any URLs in discovery responses back through _OIDC_BASE_URL.
+_issuer_host: str = (
+    urlparse(OIDC_ISSUER_URL).netloc if _OIDC_BASE_URL != OIDC_ISSUER_URL else ""
+)
+
+
+def _rebase_url(url: str) -> str:
+    """Replace OIDC_ISSUER_URL prefix with _OIDC_BASE_URL for internal routing."""
+    if _OIDC_BASE_URL != OIDC_ISSUER_URL and url.startswith(OIDC_ISSUER_URL):
+        return _OIDC_BASE_URL + url[len(OIDC_ISSUER_URL):]
+    return url
+
+
+def _oidc_get(url: str) -> requests.Response:
+    """GET an OIDC URL, routing through _OIDC_BASE_URL and spoofing Host when needed."""
+    target = _rebase_url(url)
+    headers = {"Host": _issuer_host} if _issuer_host else {}
+    resp = requests.get(target, timeout=10, headers=headers)
+    resp.raise_for_status()
+    return resp
+
 def _extract_roles(token_payload: dict) -> list:
     """Extract role list from a token, handling both Keycloak and Zitadel shapes.
 
@@ -63,10 +89,8 @@ def _fetch_discovery() -> dict:
     """Fetch and cache the OIDC discovery document."""
     global _discovery_doc
     if not _discovery_doc:
-        url = f"{_OIDC_BASE_URL}/.well-known/openid-configuration"
-        resp = requests.get(url, timeout=10)
-        resp.raise_for_status()
-        _discovery_doc = resp.json()
+        url = f"{OIDC_ISSUER_URL}/.well-known/openid-configuration"
+        _discovery_doc = _oidc_get(url).json()
     return _discovery_doc
 
 
@@ -76,9 +100,10 @@ def _get_jwks(force_refresh: bool = False) -> list:
     now = time.monotonic()
     if force_refresh or now - _jwks_cache["fetched_at"] > _JWKS_TTL:
         discovery = _fetch_discovery()
-        resp = requests.get(discovery["jwks_uri"], timeout=10)
-        resp.raise_for_status()
-        _jwks_cache = {"keys": resp.json().get("keys", []), "fetched_at": now}
+        _jwks_cache = {
+            "keys": _oidc_get(discovery["jwks_uri"]).json().get("keys", []),
+            "fetched_at": now,
+        }
     return _jwks_cache["keys"]
 
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -52,6 +52,7 @@ services:
     environment:
       - OIDC_ISSUER_URL=${OIDC_ISSUER_URL:-http://localhost:8080/realms/stuf}
       - OIDC_BASE_URL=${OIDC_BASE_URL:-http://keycloak:8080/realms/stuf}
+      - OIDC_ISSUER_HOST=${OIDC_ISSUER_HOST:-}
       - OIDC_VALID_AUDIENCES=${OIDC_VALID_AUDIENCES:-stuf-api,stuf-spa}
       - OIDC_SPA_CLIENT_ID=${OIDC_SPA_CLIENT_ID:-stuf-spa}
       - MINIO_ENDPOINT=minio:9000

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -50,9 +50,10 @@ services:
     ports:
       - "${API_PORT:-8000}:8000"
     environment:
-      - OIDC_ISSUER_URL=http://localhost:8080/realms/${KEYCLOAK_REALM:-stuf}
-      - OIDC_BASE_URL=http://keycloak:8080/realms/${KEYCLOAK_REALM:-stuf}
+      - OIDC_ISSUER_URL=${OIDC_ISSUER_URL:-http://localhost:8080/realms/stuf}
+      - OIDC_BASE_URL=${OIDC_BASE_URL:-http://keycloak:8080/realms/stuf}
       - OIDC_VALID_AUDIENCES=${OIDC_VALID_AUDIENCES:-stuf-api,stuf-spa}
+      - OIDC_SPA_CLIENT_ID=${OIDC_SPA_CLIENT_ID:-stuf-spa}
       - MINIO_ENDPOINT=minio:9000
       - MINIO_ROOT_USER=${MINIO_ROOT_USER:-minioadmin}
       - MINIO_ROOT_PASSWORD=${MINIO_ROOT_PASSWORD:-minioadmin}
@@ -70,9 +71,9 @@ services:
       - "${SPA_PORT:-3000}:3000"
     environment:
       - API_URL=${API_URL:-http://localhost:8000}
-      - KEYCLOAK_URL=${KEYCLOAK_URL:-http://localhost:8080}
-      - KEYCLOAK_REALM=${KEYCLOAK_REALM:-stuf}
-      - KEYCLOAK_CLIENT_ID=${KEYCLOAK_SPA_CLIENT_ID:-stuf-spa}
+      - OIDC_AUTHORITY=${OIDC_AUTHORITY:-http://localhost:8080/realms/stuf}
+      - OIDC_CLIENT_ID=${OIDC_CLIENT_ID:-stuf-spa}
+      - OIDC_SCOPE=${OIDC_SCOPE:-openid profile email stuf:access}
     depends_on:
       - api
 
@@ -104,7 +105,7 @@ services:
       - zitadel
     command: ["chmod", "777", "/bootstrap"]
     volumes:
-      - zitadel-bootstrap:/bootstrap
+      - ./.zitadel-bootstrap:/bootstrap
     restart: "no"
 
   zitadel:
@@ -141,7 +142,7 @@ services:
       ZITADEL_FIRSTINSTANCE_ORG_MACHINE_MACHINEKEY_TYPE: 1
       ZITADEL_FIRSTINSTANCE_MACHINEKEYPATH: /bootstrap/zitadel-admin-sa.json
     volumes:
-      - zitadel-bootstrap:/bootstrap
+      - ./.zitadel-bootstrap:/bootstrap
     ports:
       - "${ZITADEL_PORT:-8080}:8080"
     depends_on:
@@ -172,7 +173,7 @@ services:
       BOOTSTRAP_DIR: /bootstrap
       FIXTURE_PATH: /fixtures/dev/instance.yaml
     volumes:
-      - zitadel-bootstrap:/bootstrap
+      - ./.zitadel-bootstrap:/bootstrap
       - ./docker/zitadel-init:/fixtures:ro
     depends_on:
       zitadel:
@@ -196,11 +197,10 @@ services:
       ZITADEL_API_URL: http://localhost:${ZITADEL_PORT:-8080}
       PORT: ${ZITADEL_LOGIN_PORT:-8090}
     volumes:
-      - zitadel-bootstrap:/bootstrap:ro
+      - ./.zitadel-bootstrap:/bootstrap:ro
     depends_on:
       zitadel-init:
         condition: service_completed_successfully
 
 volumes:
   minio_data:
-  zitadel-bootstrap:


### PR DESCRIPTION
Ref #85, follows #95

This one is just me ensuring that  I can run an SPA developer environment with zitadel, login and see the collections etc. 

The one unexpected issue was due the development-only split host setup with the SPA running on the host needing a `localhost` access to Zitadel for login, but when requesting the /api/me to find the collections, the STUF API then using an internal zitadel DNS entry - hence the host header re-write that is switched on only in dev.

One difference from keycloak worth noting for devs: the username requires an email (admin@example.com) for Zitadel, whereas Keycloak wants just the username (admin).

## Summary

- `make spa-dev` was missing `--profile keycloak` so Keycloak never started; fixed
- New `make spa-dev-zitadel` target for local development against Zitadel, mirroring the `test-e2e-zitadel` flow: starts the Zitadel stack, runs provisioning, reads generated OIDC credentials, then starts api + spa with those vars
- `docker-compose.yml` api/spa OIDC env vars changed from hardcoded Keycloak paths to generic overridable vars (`OIDC_ISSUER_URL`, `OIDC_BASE_URL`, `OIDC_AUTHORITY`, `OIDC_CLIENT_ID`) with Keycloak defaults; Zitadel bootstrap volume changed from named to host bind-mount (`.zitadel-bootstrap/`) so `generated.env` is accessible to the Makefile
- API middleware gains `_rebase_url` / `_oidc_get` to route discovery and JWKS fetches through `OIDC_BASE_URL` while presenting the issuer hostname via an explicit `OIDC_ISSUER_HOST` env var — required because Zitadel validates the HTTP `Host` header against `EXTERNALDOMAIN` and rejects requests arriving on the internal Docker hostname
- `spa-stop` and `clean` updated to cover the new bootstrap dir and stop all profiles

## Test plan

- [x] `make spa-dev-zitadel` starts cleanly with no "network not found" errors
- [x] Login with `admin@example.com` / `Password1!` succeeds and collections appear in the sidebar
- [x] `make spa-dev` (Keycloak) still works — `--profile keycloak` now correctly starts Keycloak
- [x] `make test` passes (40 tests)
- [x] `make spa-stop` tears down both Keycloak and Zitadel services cleanly