### PR TITLE
spa: allow all hosts in vite preview mode

### DIFF
--- a/spa/vite.config.ts
+++ b/spa/vite.config.ts
@@ -17,6 +17,10 @@ export default defineConfig({
     // Allow Docker container hostnames
     allowedHosts: ["spa-e2e", "localhost", "127.0.0.1", "all"],
   },
+  preview: {
+    host: "0.0.0.0",
+    allowedHosts: true,
+  },
   build: {
     outDir: "build",
   },


### PR DESCRIPTION
`vite preview` validates incoming Host headers against `preview.allowedHosts`, which is separate from the `server.allowedHosts` block used by `vite dev`. Without a `preview` config, Vite 7 blocks any host not on its default allowlist, which is just localhost — so proxied deployments at custom subdomains all get a 403.

Setting `preview.allowedHosts: true` restores the behaviour the `server` block was already expressing: the container accepts requests from any hostname, with TLS/auth left to the upstream nginx proxy.