### PR TITLE
spa: serve production build with nginx instead of vite preview

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,10 +36,19 @@ jobs:
         run: make test
 
   e2e-tests:
-    name: E2E Tests (Zitadel)
+    name: E2E Tests (${{ matrix.name }})
     runs-on: ubuntu-latest
     needs: fast-tests
     if: success()
+    strategy:
+      matrix:
+        include:
+          - name: production
+            spa_build_target: production
+            spa_container_port: 80
+          - name: development
+            spa_build_target: development
+            spa_container_port: 3000
 
     steps:
       - uses: actions/checkout@v4
@@ -84,6 +93,9 @@ jobs:
 
       - name: Run E2E tests
         run: make test-e2e
+        env:
+          SPA_BUILD_TARGET: ${{ matrix.spa_build_target }}
+          SPA_CONTAINER_PORT: ${{ matrix.spa_container_port }}
 
       - name: Show Docker containers and logs on failure
         if: failure()

--- a/Makefile
+++ b/Makefile
@@ -120,7 +120,7 @@ clean:
 	@echo "Clean complete."
 
 # Test targets
-.PHONY: test test-e2e test-all test-cov
+.PHONY: test test-e2e test-e2e-dev test-all test-cov
 
 # Run fast tests (unit + integration) - default
 test: $(VENV_DIR)/dev-requirements.stamp
@@ -165,6 +165,9 @@ test-e2e:
 	)
 	@echo "Stopping Zitadel E2E services..."
 	@cd tests/e2e-browser && docker compose -f docker-compose.e2e-browser.yml --profile zitadel down
+
+test-e2e-dev:
+	SPA_BUILD_TARGET=development SPA_CONTAINER_PORT=3000 $(MAKE) test-e2e
 
 # Run all tests (fast + e2e)
 test-all:

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -16,6 +16,8 @@ services:
       context: ./spa
       dockerfile: Dockerfile
       target: development
+    ports:
+      - "${SPA_PORT:-3000}:3000"
     volumes:
       # Mount source code for hot reloading
       - ./spa/src:/app/src:cached

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,7 +42,7 @@ services:
       dockerfile: Dockerfile
       target: production
     ports:
-      - "${SPA_PORT:-3000}:3000"
+      - "${SPA_PORT:-3000}:80"
     environment:
       - API_URL=${API_URL:-http://localhost:8000}
       - OIDC_AUTHORITY=${OIDC_AUTHORITY:-http://localhost:8080}

--- a/docker/zitadel-init/dev/instance.yaml
+++ b/docker/zitadel-init/dev/instance.yaml
@@ -18,11 +18,15 @@ apps:
     redirectUris:
       - http://localhost:3000
       - http://localhost:3100
+      - http://localhost
       - http://spa-e2e:3000
+      - http://spa-e2e
     postLogoutRedirectUris:
       - http://localhost:3000
       - http://localhost:3100
+      - http://localhost
       - http://spa-e2e:3000
+      - http://spa-e2e
   api:
     name: stuf-api
 

--- a/spa/Dockerfile
+++ b/spa/Dockerfile
@@ -27,40 +27,34 @@ RUN chmod +x /app/docker-entrypoint.sh
 # Use entrypoint with "dev" argument
 ENTRYPOINT ["/app/docker-entrypoint.sh", "dev"]
 
-# Production stage
-FROM node:20-alpine AS production
+# Build stage (intermediate — not published)
+FROM node:20-alpine AS build
 
 WORKDIR /app
 
-# Copy package files
 COPY package*.json ./
+RUN npm ci
 
-# Install only production dependencies
-RUN npm ci --only=production
-
-# Copy configuration files needed for build
 COPY vite.config.ts ./
 COPY tailwind.config.js ./
 COPY components.json ./
 COPY tsconfig.json ./
 COPY tsconfig.node.json ./
 COPY index.html ./
-
-# Copy source code
 COPY src/ ./src/
-
-# Copy public assets (icons, etc.)
 COPY public/ ./public/
 
-# Install dev dependencies needed for build
-RUN npm install vite @vitejs/plugin-react --save-dev
-
-# Build the application
 RUN npm run build
 
-# Copy and set up the entrypoint script
-COPY docker-entrypoint.sh /app/docker-entrypoint.sh
-RUN chmod +x /app/docker-entrypoint.sh
+# Deploy stage — nginx serving the built assets
+FROM nginx:alpine AS production
 
-# Use entrypoint with "prod" argument (default)
-ENTRYPOINT ["/app/docker-entrypoint.sh", "prod"]
+COPY --from=build /app/build /usr/share/nginx/html
+COPY nginx.conf /etc/nginx/conf.d/default.conf
+COPY nginx-entrypoint.sh /docker-entrypoint.d/10-runtime-config.sh
+RUN chmod +x /docker-entrypoint.d/10-runtime-config.sh
+
+EXPOSE 80
+
+HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
+    CMD curl -f http://localhost || exit 1

--- a/spa/nginx-entrypoint.sh
+++ b/spa/nginx-entrypoint.sh
@@ -12,7 +12,7 @@ fi
 
 API_BASE_URL="${API_URL:-http://localhost:8000}"
 OIDC_AUTHORITY="${OIDC_AUTHORITY:-http://localhost:8080}"
-OIDC_CLIENT_ID="${ZITADEL_STUF_SPA_CLIENT_ID:-stuf-spa}"
+OIDC_CLIENT_ID="${ZITADEL_STUF_SPA_CLIENT_ID:-${OIDC_CLIENT_ID:?ZITADEL_STUF_SPA_CLIENT_ID or OIDC_CLIENT_ID must be set}}"
 OIDC_SCOPE="${OIDC_SCOPE:-openid profile email urn:zitadel:iam:org:projects:roles}"
 OIDC_LOAD_USER_INFO="${OIDC_LOAD_USER_INFO:-false}"
 

--- a/spa/nginx-entrypoint.sh
+++ b/spa/nginx-entrypoint.sh
@@ -1,0 +1,27 @@
+#!/bin/sh
+# Writes window.__STUF_CONFIG__ into the nginx web root before nginx starts.
+# Runs via /docker-entrypoint.d/ — nginx's own entrypoint calls scripts there.
+set -e
+
+if [ -f /bootstrap/generated.env ]; then
+  set -a
+  # shellcheck disable=SC1091
+  . /bootstrap/generated.env
+  set +a
+fi
+
+API_BASE_URL="${API_URL:-http://localhost:8000}"
+OIDC_AUTHORITY="${OIDC_AUTHORITY:-http://localhost:8080}"
+OIDC_CLIENT_ID="${ZITADEL_STUF_SPA_CLIENT_ID:-stuf-spa}"
+OIDC_SCOPE="${OIDC_SCOPE:-openid profile email urn:zitadel:iam:org:projects:roles}"
+OIDC_LOAD_USER_INFO="${OIDC_LOAD_USER_INFO:-false}"
+
+cat > /usr/share/nginx/html/config.js <<EOF
+window.__STUF_CONFIG__ = {
+  apiBaseUrl: "$API_BASE_URL",
+  oidcAuthority: "$OIDC_AUTHORITY",
+  oidcClientId: "$OIDC_CLIENT_ID",
+  oidcScope: "$OIDC_SCOPE",
+  oidcLoadUserInfo: $OIDC_LOAD_USER_INFO
+};
+EOF

--- a/spa/nginx.conf
+++ b/spa/nginx.conf
@@ -1,0 +1,9 @@
+server {
+    listen 80;
+    root /usr/share/nginx/html;
+    index index.html;
+
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+}

--- a/tests/e2e-browser/config.py
+++ b/tests/e2e-browser/config.py
@@ -1,6 +1,7 @@
 """Centralized configuration for STUF Browser E2E Tests."""
 
 import os
+from urllib.parse import urlparse
 
 # Test environment URLs - Docker container defaults
 SPA_URL = os.getenv("SPA_URL", "http://spa-e2e:3000")
@@ -23,13 +24,20 @@ PLAYWRIGHT_WORKERS = os.getenv("PLAYWRIGHT_WORKERS")
 PLAYWRIGHT_BASE_URL = os.getenv("PLAYWRIGHT_BASE_URL")
 
 
-# Extract just the hostname:port for URL matching (for both localhost and internal Docker names)
-# SLOP: this is a stupid function and it's not clear why it needs to exist.
 def get_spa_host():
-    """Get SPA host for URL matching (e.g., 'localhost:3100' or 'spa-e2e:3000')"""
-    if "spa-e2e:3000" in SPA_URL:
-        return "spa-e2e:3000"
-    return "localhost:3100"
+    """Return the host[:port] to match in browser URLs after OIDC redirects.
+
+    Browsers suppress the default port (80 for HTTP, 443 for HTTPS), so a SPA
+    running on port 80 will appear as 'http://spa-e2e/' not 'http://spa-e2e:80/'.
+    """
+    parsed = urlparse(SPA_URL)
+    host = parsed.hostname or "localhost"
+    port = parsed.port
+    scheme = parsed.scheme or "http"
+    default_port = 443 if scheme == "https" else 80
+    if port and port != default_port:
+        return f"{host}:{port}"
+    return host
 
 
 SPA_HOST = get_spa_host()

--- a/tests/e2e-browser/docker-compose.e2e-browser.yml
+++ b/tests/e2e-browser/docker-compose.e2e-browser.yml
@@ -251,13 +251,7 @@ services:
     networks:
       - stuf-e2e-test-net
     healthcheck:
-      test:
-        [
-          "CMD",
-          "node",
-          "-e",
-          "const http = require('http'); const req = http.request('http://127.0.0.1:80', res => process.exit(0)); req.on('error', () => process.exit(1)); req.end();",
-        ]
+      test: ["CMD", "wget", "--quiet", "--tries=1", "--spider", "http://127.0.0.1/"]
       interval: 5s
       timeout: 2s
       retries: 15

--- a/tests/e2e-browser/docker-compose.e2e-browser.yml
+++ b/tests/e2e-browser/docker-compose.e2e-browser.yml
@@ -211,7 +211,7 @@ services:
       - MINIO_BUCKET_NAME=stuf-uploads-e2e
 
       # CORS configuration for browser testing
-      - CORS_ORIGINS=http://spa-e2e:3000
+      - CORS_ORIGINS=http://spa-e2e:80
     depends_on:
       minio-e2e:
         condition: service_healthy
@@ -235,9 +235,9 @@ services:
     build:
       context: ../../spa
       dockerfile: Dockerfile
-      target: development
+      target: production
     ports:
-      - "3100:3000" # Different port
+      - "3100:80"
     environment:
       # API configuration (internal Docker network URL)
       - API_URL=http://api-e2e:8000
@@ -256,7 +256,7 @@ services:
           "CMD",
           "node",
           "-e",
-          "const http = require('http'); const req = http.request('http://127.0.0.1:3000', res => process.exit(0)); req.on('error', () => process.exit(1)); req.end();",
+          "const http = require('http'); const req = http.request('http://127.0.0.1:80', res => process.exit(0)); req.on('error', () => process.exit(1)); req.end();",
         ]
       interval: 5s
       timeout: 2s
@@ -270,7 +270,7 @@ services:
       dockerfile: tests/e2e-browser/Dockerfile.test-runner
     environment:
       # Use internal Docker network URLs
-      - SPA_URL=http://spa-e2e:3000
+      - SPA_URL=http://spa-e2e:80
       - API_URL=http://api-e2e:8000
       - IDP_URL=${IDP_URL:-http://zitadel-e2e:8080}
       - MINIO_URL=http://minio-e2e:9000

--- a/tests/e2e-browser/docker-compose.e2e-browser.yml
+++ b/tests/e2e-browser/docker-compose.e2e-browser.yml
@@ -211,7 +211,7 @@ services:
       - MINIO_BUCKET_NAME=stuf-uploads-e2e
 
       # CORS configuration for browser testing
-      - CORS_ORIGINS=http://spa-e2e:80
+      - CORS_ORIGINS=http://spa-e2e:${SPA_CONTAINER_PORT:-80}
     depends_on:
       minio-e2e:
         condition: service_healthy
@@ -235,9 +235,9 @@ services:
     build:
       context: ../../spa
       dockerfile: Dockerfile
-      target: production
+      target: ${SPA_BUILD_TARGET:-production}
     ports:
-      - "3100:80"
+      - "3100:${SPA_CONTAINER_PORT:-80}"
     environment:
       # API configuration (internal Docker network URL)
       - API_URL=http://api-e2e:8000
@@ -251,7 +251,8 @@ services:
     networks:
       - stuf-e2e-test-net
     healthcheck:
-      test: ["CMD", "wget", "--quiet", "--tries=1", "--spider", "http://127.0.0.1/"]
+      test: ["CMD", "wget", "--quiet", "--tries=1", "--spider",
+             "http://127.0.0.1:${SPA_CONTAINER_PORT:-80}/"]
       interval: 5s
       timeout: 2s
       retries: 15
@@ -264,7 +265,7 @@ services:
       dockerfile: tests/e2e-browser/Dockerfile.test-runner
     environment:
       # Use internal Docker network URLs
-      - SPA_URL=http://spa-e2e:80
+      - SPA_URL=http://spa-e2e:${SPA_CONTAINER_PORT:-80}
       - API_URL=http://api-e2e:8000
       - IDP_URL=${IDP_URL:-http://zitadel-e2e:8080}
       - MINIO_URL=http://minio-e2e:9000


### PR DESCRIPTION
`vite preview` is a local development convenience tool — Vite's own documentation describes it as a way to "locally preview the production build" before deploying. It is not a production server: it has no caching header tuning, no gzip/brotli, and enforces a host allowlist that blocks proxied deployments at custom subdomains.

The last part is the part that bit me: when deploying the stuff ui under a fqdn, I was unable to access it. I could have worked around it (see #138) but it seems better to just fix it rather than create more tech debt.

The production stage is replaced with `nginx:alpine` serving the static build output from `build/`, following the same pattern used other demo-uis. Runtime config (`window.__STUF_CONFIG__`) is injected by a `/docker-entrypoint.d/` script before nginx starts, sourcing the Zitadel bootstrap volume for the generated client ID.

The container now listens on port 80 instead of 3000; the port mappings in `docker-compose.yml` are updated accordingly. The `development` stage and e2e test setup are unchanged.