### PR TITLE
fix(api): drop --reload dev server in production image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -247,7 +247,7 @@ build-containers:
 	@echo "SPA Image: $(SPA_IMAGE)"
 	@echo ""
 	@echo "Building API container..."
-	@docker build -t $(API_IMAGE):latest ./api
+	@docker build --target production -t $(API_IMAGE):latest ./api
 	@echo "Building SPA container..."
 	@docker build --target production -t $(SPA_IMAGE):latest ./spa
 	@echo "All containers built successfully!"

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,13 +1,48 @@
-FROM python:3.12-slim
+# ============================================================================
+# Base stage - shared dependencies and source
+# ============================================================================
+FROM python:3.12-slim AS base
+
+ENV PYTHONUNBUFFERED=1
+ENV PYTHONDONTWRITEBYTECODE=1
+
+# curl is used by the production HEALTHCHECK
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    curl \
+    && rm -rf /var/lib/apt/lists/*
+
+# Run as a non-root user
+RUN useradd --create-home --shell /bin/bash stuf
 
 WORKDIR /app
 
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
-COPY . .
+COPY --chown=stuf:stuf . .
 
 EXPOSE 8000
 
-# Use uvicorn to run the FastAPI application
+# ============================================================================
+# Development stage - auto-reloading server for local hot-reloading.
+# docker-compose.dev.yml mounts ./api over /app so edits reload live.
+# ============================================================================
+FROM base AS development
+
+USER stuf
+
 CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000", "--reload"]
+
+# ============================================================================
+# Production stage - no --reload; multiple workers. This is the published
+# image (`make build-containers` builds --target production). Ordered last so
+# a target-less `docker build ./api` also yields the production image.
+# ============================================================================
+FROM base AS production
+
+USER stuf
+
+HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
+    CMD curl -f http://localhost:8000/api/health || exit 1
+
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000", "--workers", "4"]

--- a/api/main.py
+++ b/api/main.py
@@ -83,5 +83,8 @@ def get_current_principal_info(
 
 if __name__ == "__main__":
     port = int(os.environ.get("API_PORT", 8000))
+    # Auto-reload is a development convenience; off by default so this entry
+    # point is never accidentally a dev server in front of public traffic.
+    reload = os.environ.get("API_RELOAD", "false").lower() == "true"
 
-    uvicorn.run("main:app", host="0.0.0.0", port=port, reload=True)
+    uvicorn.run("main:app", host="0.0.0.0", port=port, reload=reload)

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -2,6 +2,11 @@
 # Provides fast hot-reloading development environment
 services:
   api:
+    build:
+      context: ./api
+      dockerfile: Dockerfile
+      # development target runs uvicorn with --reload
+      target: development
     volumes:
       # Mount API source code for hot reloading
       - ./api:/app:cached

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,7 @@ services:
     build:
       context: ./api
       dockerfile: Dockerfile
+      target: production
     ports:
       - "${API_PORT:-8000}:8000"
     environment:


### PR DESCRIPTION
## Summary

The published `stuf-api` image baked `uvicorn … --reload` into its `CMD`, so the production deployment fronted public traffic with the development auto-reload server (single worker + file watcher).

## Changes

- **`api/Dockerfile`** — split into a `base` → `development` / `production` multi-stage build, mirroring the SPA's existing pattern:
  - `development`: `uvicorn … --reload` (local hot-reload, source mounted by `docker-compose.dev.yml`)
  - `production`: `uvicorn … --workers 4`, **no `--reload`**; ordered last so a target-less build also yields production
  - Hardening: non-root `stuf` user and a `HEALTHCHECK` on `/api/health`
- **`docker-compose.yml`** — api build now `target: production`
- **`docker-compose.dev.yml`** — api build now `target: development` (keeps local hot-reload)
- **`Makefile`** — `build-containers` builds the published API image `--target production`
- **`api/main.py`** — `__main__` reload gated behind `API_RELOAD` (default off) instead of hardcoded `reload=True`

## Verification

Both targets build. Inspected images confirm production runs as `stuf` with `--workers 4` (boots a multi-worker parent, no reloader) and development runs `--reload`.